### PR TITLE
TEST_MANUAL.mdにConformance Suiteの起動のためのコマンドを追加

### DIFF
--- a/TEST_MANUAL.md
+++ b/TEST_MANUAL.md
@@ -50,12 +50,12 @@ curl -sS -X POST http://localhost:8080/api/v1/admin/clients \
 ```bash
 git clone git@github.com:openid-certification/conformance-suite.git
 cd conformance-suite
-mvn  package
+docker compose -f builder-compose.yml run --rm builder
 docker compose up
 ```
 
 ## 5. Suite 側の設定
-
+`localhost.emobix.co.uk:8443`　にアクセス
 Suite の新規テスト作成画面で、以下を設定する。
 
 - Alias: 好きな名称

--- a/TEST_MANUAL.md
+++ b/TEST_MANUAL.md
@@ -45,6 +45,8 @@ curl -sS -X POST http://localhost:8080/api/v1/admin/clients \
 
 ```bash
 git clone git@github.com:openid-certification/conformance-suite.git
+cd conformance-suite
+mvn  package
 docker compose up
 ```
 

--- a/TEST_MANUAL.md
+++ b/TEST_MANUAL.md
@@ -43,6 +43,10 @@ curl -sS -X POST http://localhost:8080/api/v1/admin/clients \
 
 ## 4. Conformance Suite の起動
 
+必要なもの:
+- Java 17（`java` / `javac` がともに 17 であること）
+- Maven
+
 ```bash
 git clone git@github.com:openid-certification/conformance-suite.git
 cd conformance-suite

--- a/TEST_MANUAL.md
+++ b/TEST_MANUAL.md
@@ -43,10 +43,6 @@ curl -sS -X POST http://localhost:8080/api/v1/admin/clients \
 
 ## 4. Conformance Suite の起動
 
-必要なもの:
-- Java 17（`java` / `javac` がともに 17 であること）
-- Maven
-
 ```bash
 git clone git@github.com:openid-certification/conformance-suite.git
 cd conformance-suite


### PR DESCRIPTION
portal-oidcのテスト実行をした際に必要なコマンドを追記しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Conformance Suite の起動手順を更新しました。Java 17 と Maven を前提に追加し、クローン後に該当ディレクトリへ移動してビルド用コンテナ／ビルド手順を先に実行してから、サービス群を起動する流れに変更しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->