### PR TITLE
chore(dev): mongo v8 に対応した設定をつける

### DIFF
--- a/.github/conformance/docker-compose.yml
+++ b/.github/conformance/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   server:
     image: ${CONFORMANCE_SERVER_IMAGE}
     environment:
-      - openid.mongodb.targetFeatureCompatibilityVersion=8.0
+      - openid.mongodb.targetFeatureCompatibilityVersion=8.2
     command: >
       java
       -Djdk.tls.maxHandshakeMessageSize=65536

--- a/.github/conformance/docker-compose.yml
+++ b/.github/conformance/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - server
   server:
     image: ${CONFORMANCE_SERVER_IMAGE}
+    environment:
+      - openid.mongodb.targetFeatureCompatibilityVersion=8.0
     command: >
       java
       -Djdk.tls.maxHandshakeMessageSize=65536


### PR DESCRIPTION
following: #90

https://github.com/openid-certification/conformance-suite/blob/1274feed4ebf01c8f27e580d6fcf90d7f2579a18/src/main/resources/application.properties#L4-L7 で設定されている FCV6.0 を上書きする

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

この変更は開発・テスト環境のインフラストラクチャ構成の更新であり、エンドユーザーに対する機能変更や改善はございません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->