### PR TITLE
fix(db): oidc_sessions に authorize_code の FK を追加 (#73)

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -74,7 +74,9 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (authorize_code),
   CONSTRAINT fk_oidc_sessions_client FOREIGN KEY (client_id)
-    REFERENCES clients (client_id) ON DELETE CASCADE
+    REFERENCES clients (client_id) ON DELETE CASCADE,
+  CONSTRAINT fk_oidc_sessions_authorize_code FOREIGN KEY (authorize_code)
+    REFERENCES authorization_codes (code) ON DELETE CASCADE
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);

--- a/internal/repository/oauth/oidc.go
+++ b/internal/repository/oauth/oidc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/ory/fosite"
@@ -11,6 +12,19 @@ import (
 	"github.com/traPtitech/portal-oidc/internal/domain"
 	"github.com/traPtitech/portal-oidc/internal/repository"
 )
+
+// authorizeCodeSignature extracts the signature portion of a fosite-issued
+// authorization code. fosite emits codes formatted as "<key>.<signature>"
+// (HMACStrategy) and stores the signature alone as the lookup key in
+// CreateAuthorizeCodeSession. CreateOpenIDConnectSession, however, is invoked
+// with the full code, so we strip the key half here to keep oidc_sessions
+// referentially consistent with authorization_codes.
+func authorizeCodeSignature(code string) string {
+	if idx := strings.LastIndex(code, "."); idx >= 0 && idx+1 < len(code) {
+		return code[idx+1:]
+	}
+	return code
+}
 
 func (s *Storage) CreateOpenIDConnectSession(ctx context.Context, authorizeCode string, requester fosite.Requester) error {
 	sess, ok := requester.GetSession().(*Session)
@@ -28,7 +42,7 @@ func (s *Storage) CreateOpenIDConnectSession(ctx context.Context, authorizeCode 
 	}
 
 	return s.getOIDCSessions(ctx).Create(ctx, domain.OIDCSession{
-		AuthorizeCode: authorizeCode,
+		AuthorizeCode: authorizeCodeSignature(authorizeCode),
 		ClientID:      clientID,
 		UserID:        userID,
 		Nonce:         requester.GetRequestForm().Get("nonce"),
@@ -39,7 +53,7 @@ func (s *Storage) CreateOpenIDConnectSession(ctx context.Context, authorizeCode 
 }
 
 func (s *Storage) GetOpenIDConnectSession(ctx context.Context, authorizeCode string, _ fosite.Requester) (fosite.Requester, error) {
-	oidcSession, err := s.getOIDCSessions(ctx).Get(ctx, authorizeCode)
+	oidcSession, err := s.getOIDCSessions(ctx).Get(ctx, authorizeCodeSignature(authorizeCode))
 	if err != nil {
 		if errors.Is(err, repository.ErrOIDCSessionNotFound) {
 			return nil, fosite.ErrNotFound
@@ -63,5 +77,5 @@ func (s *Storage) GetOpenIDConnectSession(ctx context.Context, authorizeCode str
 }
 
 func (s *Storage) DeleteOpenIDConnectSession(ctx context.Context, authorizeCode string) error {
-	return s.getOIDCSessions(ctx).Delete(ctx, authorizeCode)
+	return s.getOIDCSessions(ctx).Delete(ctx, authorizeCodeSignature(authorizeCode))
 }


### PR DESCRIPTION
## 概要

`oidc_sessions.authorize_code` から `authorization_codes.code` への外部キー制約を追加する。`ON DELETE CASCADE` により、認可コード削除時に対応する OIDC セッションも自動削除される。

## 背景

- closes #73
- PR #53 のレビュー指摘: https://github.com/traPtitech/portal-oidc/pull/53#discussion_r2830230643
- 現状 `DeleteExpiredAuthorizationCodes` で期限切れコードを削除しても、`oidc_sessions` に孤児行が残る
- MariaDB 時代に指摘されていた型長不一致 (`varchar(255)` vs `varchar(64)`) は PostgreSQL 移行 (#112) で `TEXT` に統一済み。残課題が今回の FK

## 変更

- `db/schema.sql`: `oidc_sessions` に `fk_oidc_sessions_authorize_code` 制約を追加

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] `mise run schema:apply:oidc` で schema 適用が成功すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チューニング・改善**
  * 認証およびセッション管理システムの各コンポーネント間のデータ参照整合性を強化しました。セッション情報と認可プロセス間の関係性を一層堅牢化することにより、システム全体の信頼性と安定性が大幅に向上し、データ管理の正確性が確保されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->