### PR TITLE
docs(config): config.yaml と compose env の優先順位を明示

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Access:
 - [DB schema (portal-oidc)](./docs/db/oidc)
 - [DB schema (traPortal v2)](./docs/db/portal)
 
+## Configuration
+
+Settings are loaded in priority order (later wins):
+
+1. Built-in defaults (`cmd/config.go`)
+2. `config.yaml` in the working directory (or `--config <path>`) — local-dev defaults (host: `localhost`)
+3. `OIDC_*` environment variables — used by `compose.yaml` to override DB hosts/ports for the Docker network (e.g. `OIDC_DATABASE__HOST=oidc`)
+
+Env keys are mapped to koanf paths by stripping the `OIDC_` prefix, lowercasing, and turning `__` into `.` (so `OIDC_PORTAL__DATABASE__HOST` → `portal.database.host`).
+
 ## Development
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,8 +11,10 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - CONFIG_FILE=/app/config.yaml
       - TZ=Asia/Tokyo
+      # Docker network overrides for config.yaml (which defaults to localhost
+      # for non-Docker development). Env keys map to koanf paths via the
+      # `OIDC_` prefix and `__` -> `.` separator (see cmd/config.go).
       - OIDC_DATABASE__HOST=oidc
       - OIDC_DATABASE__PORT=5433
       - OIDC_PORTAL__DATABASE__HOST=portal


### PR DESCRIPTION
## 概要

`compose.yaml` の `OIDC_*` 環境変数と `config.yaml` の使い分けを明示するため、コメントと README セクションを追加する。

## 背景

PR #53 のレビュー指摘:
> こちらは config.yaml には追記しない感じなんでしょうか…？ 現時点での環境変数と config.yaml の使い分けがあまりわかっておらず…

実態としては:
- `config.yaml` は localhost ベースのローカル開発用デフォルト
- `OIDC_*` env は Docker ネットワーク内で localhost を上書きするためのもの

両者を統合せず、用途が異なる旨をドキュメントで明示する方針を採用。

## 変更

- `compose.yaml`: `OIDC_*` env の上にコメントで意図を説明
- `compose.yaml`: 未使用の `CONFIG_FILE` 環境変数を削除 (`cmd/main.go` は参照していない)
- `README.md`: Configuration セクションを追加。優先順位 (defaults → config.yaml → env) と koanf キーマッピング (`OIDC_FOO__BAR` → `foo.bar`) を記載

## テスト

- [ ] CI パス
- [ ] `mise run dev` で起動できること (動作互換性は変わらない)