### PR TITLE
security(oauth): 認可コード再利用時に発行済みトークンを失効

### DIFF
--- a/internal/repository/oauth/authcode.go
+++ b/internal/repository/oauth/authcode.go
@@ -75,6 +75,13 @@ func (s *Storage) GetAuthorizeCodeSession(ctx context.Context, code string, sess
 	req := newFositeRequest(code, authCode.CreatedAt, client, sess, authCode.Scopes, form)
 
 	if authCode.Used {
+		// RFC 6749 §4.1.2: on authorization code reuse, the server SHOULD revoke
+		// all tokens previously issued from this code. The code itself was used as
+		// the fosite request ID (see newFositeRequest in storage.go), so all tokens
+		// derived from it carry the same request_id.
+		if delErr := s.getTokens(ctx).DeleteByRequestID(ctx, code); delErr != nil {
+			return req, errors.Join(fosite.ErrInvalidatedAuthorizeCode, delErr)
+		}
 		return req, fosite.ErrInvalidatedAuthorizeCode
 	}
 


### PR DESCRIPTION
## 概要

認可コードが2回以上使用された場合、そのコードから発行された全てのアクセス/リフレッシュトークンを失効させる。

## 背景

PR #53 のレビュー指摘 (RFC 6749 §4.1.2 MUST):
> 認可コードが 2 回使われた場合にそれを検知する必要がありそうです…？
> それが検知された場合は、当該 req を拒否するだけでなく、関連する token の一括無効化処理も推奨されているようです

参照: https://openid-foundation-japan.github.io/rfc6749.ja.html#code-authz-resp

## 変更

- `internal/repository/oauth/authcode.go`: `GetAuthorizeCodeSession` で `used = true` 検知時、`tokens.DeleteByRequestID(code)` を呼んで関連トークンを削除
- 認可コードを fosite request ID として使用しているため (see `newFositeRequest`)、`request_id = code` で発行された全トークンが対象
- 削除エラーは `errors.Join(fosite.ErrInvalidatedAuthorizeCode, delErr)` で包んで返却。fosite 側で `errors.Is` 検出が引き続き機能する

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] `go build ./...` 成功 (確認済み)
- [ ] `golangci-lint run` 0 issues (確認済み)