### PR TITLE
feat(oauth): リフレッシュトークンのローテーション実装 + tokens.access_token を NULL 許可

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -47,13 +47,14 @@ CREATE TABLE IF NOT EXISTS tokens (
   request_id TEXT NOT NULL,
   client_id UUID NOT NULL,
   user_id UUID NOT NULL,
-  access_token TEXT NOT NULL,
+  access_token TEXT NULL,
   refresh_token TEXT NULL,
   scopes TEXT NOT NULL,
   expires_at TIMESTAMPTZ NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   CONSTRAINT idx_tokens_access_token UNIQUE (access_token),
+  CONSTRAINT chk_tokens_at_least_one_token CHECK (access_token IS NOT NULL OR refresh_token IS NOT NULL),
   CONSTRAINT fk_tokens_client FOREIGN KEY (client_id) REFERENCES clients (client_id) ON DELETE CASCADE
 );
 

--- a/internal/repository/oauth/token.go
+++ b/internal/repository/oauth/token.go
@@ -92,8 +92,8 @@ func (s *Storage) CreateRefreshTokenSession(ctx context.Context, signature strin
 	})
 }
 
-func (s *Storage) RotateRefreshToken(ctx context.Context, requestID string, refreshTokenSignature string) error {
-	return nil
+func (s *Storage) RotateRefreshToken(ctx context.Context, _ string, refreshTokenSignature string) error {
+	return s.getTokens(ctx).DeleteByRefreshToken(ctx, refreshTokenSignature)
 }
 
 func (s *Storage) GetRefreshTokenSession(ctx context.Context, signature string, session fosite.Session) (fosite.Requester, error) {

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -52,7 +52,7 @@ type Token struct {
 	RequestID    string         `json:"request_id"`
 	ClientID     uuid.UUID      `json:"client_id"`
 	UserID       uuid.UUID      `json:"user_id"`
-	AccessToken  string         `json:"access_token"`
+	AccessToken  sql.NullString `json:"access_token"`
 	RefreshToken sql.NullString `json:"refresh_token"`
 	Scopes       string         `json:"scopes"`
 	ExpiresAt    time.Time      `json:"expires_at"`

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -144,7 +144,7 @@ type CreateTokenParams struct {
 	RequestID    string         `json:"request_id"`
 	ClientID     uuid.UUID      `json:"client_id"`
 	UserID       uuid.UUID      `json:"user_id"`
-	AccessToken  string         `json:"access_token"`
+	AccessToken  sql.NullString `json:"access_token"`
 	RefreshToken sql.NullString `json:"refresh_token"`
 	Scopes       string         `json:"scopes"`
 	ExpiresAt    time.Time      `json:"expires_at"`
@@ -259,7 +259,7 @@ const deleteTokenByAccessToken = `-- name: DeleteTokenByAccessToken :exec
 DELETE FROM tokens WHERE access_token = $1
 `
 
-func (q *Queries) DeleteTokenByAccessToken(ctx context.Context, accessToken string) error {
+func (q *Queries) DeleteTokenByAccessToken(ctx context.Context, accessToken sql.NullString) error {
 	_, err := q.exec(ctx, q.deleteTokenByAccessTokenStmt, deleteTokenByAccessToken, accessToken)
 	return err
 }
@@ -362,7 +362,7 @@ const getTokenByAccessToken = `-- name: GetTokenByAccessToken :one
 SELECT id, request_id, client_id, user_id, access_token, refresh_token, scopes, expires_at, created_at FROM tokens WHERE access_token = $1
 `
 
-func (q *Queries) GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error) {
+func (q *Queries) GetTokenByAccessToken(ctx context.Context, accessToken sql.NullString) (Token, error) {
 	row := q.queryRow(ctx, q.getTokenByAccessTokenStmt, getTokenByAccessToken, accessToken)
 	var i Token
 	err := row.Scan(

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -30,14 +30,14 @@ type Querier interface {
 	DeleteExpiredTokens(ctx context.Context) error
 	DeleteOIDCSession(ctx context.Context, authorizeCode string) error
 	DeleteToken(ctx context.Context, id uuid.UUID) error
-	DeleteTokenByAccessToken(ctx context.Context, accessToken string) error
+	DeleteTokenByAccessToken(ctx context.Context, accessToken sql.NullString) error
 	DeleteTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) error
 	DeleteTokensByRequestID(ctx context.Context, requestID string) error
 	DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTokensByUserAndClientParams) error
 	GetAuthorizationCode(ctx context.Context, code string) (AuthorizationCode, error)
 	GetClient(ctx context.Context, clientID uuid.UUID) (Client, error)
 	GetOIDCSession(ctx context.Context, authorizeCode string) (OidcSession, error)
-	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
+	GetTokenByAccessToken(ctx context.Context, accessToken sql.NullString) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
 	ListClients(ctx context.Context) ([]Client, error)

--- a/internal/repository/token.go
+++ b/internal/repository/token.go
@@ -35,11 +35,14 @@ func NewTokenRepository(queries *oidc.Queries) TokenRepository {
 
 func (r *tokenRepository) Create(ctx context.Context, token domain.Token) error {
 	return r.queries.CreateToken(ctx, oidc.CreateTokenParams{
-		ID:          token.ID,
-		RequestID:   token.RequestID,
-		ClientID:    token.ClientID,
-		UserID:      token.UserID,
-		AccessToken: token.AccessToken,
+		ID:        token.ID,
+		RequestID: token.RequestID,
+		ClientID:  token.ClientID,
+		UserID:    token.UserID,
+		AccessToken: sql.NullString{
+			String: token.AccessToken,
+			Valid:  token.AccessToken != "",
+		},
 		RefreshToken: sql.NullString{
 			String: token.RefreshToken,
 			Valid:  token.RefreshToken != "",
@@ -50,7 +53,10 @@ func (r *tokenRepository) Create(ctx context.Context, token domain.Token) error 
 }
 
 func (r *tokenRepository) GetByAccessToken(ctx context.Context, accessToken string) (domain.Token, error) {
-	dbToken, err := r.queries.GetTokenByAccessToken(ctx, accessToken)
+	dbToken, err := r.queries.GetTokenByAccessToken(ctx, sql.NullString{
+		String: accessToken,
+		Valid:  true,
+	})
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return domain.Token{}, ErrTokenNotFound
@@ -89,7 +95,10 @@ func (r *tokenRepository) GetByID(ctx context.Context, id uuid.UUID) (domain.Tok
 }
 
 func (r *tokenRepository) DeleteByAccessToken(ctx context.Context, accessToken string) error {
-	return r.queries.DeleteTokenByAccessToken(ctx, accessToken)
+	return r.queries.DeleteTokenByAccessToken(ctx, sql.NullString{
+		String: accessToken,
+		Valid:  true,
+	})
 }
 
 func (r *tokenRepository) DeleteByRefreshToken(ctx context.Context, refreshToken string) error {
@@ -113,7 +122,7 @@ func toDomainToken(db oidc.Token) domain.Token {
 		RequestID:    db.RequestID,
 		ClientID:     db.ClientID,
 		UserID:       db.UserID,
-		AccessToken:  db.AccessToken,
+		AccessToken:  db.AccessToken.String,
 		RefreshToken: db.RefreshToken.String,
 		Scopes:       splitScopes(db.Scopes),
 		ExpiresAt:    db.ExpiresAt,


### PR DESCRIPTION
## 概要

`RotateRefreshToken` のスタブを実装。同時に `tokens.access_token` の NOT NULL を解除する設計バグを修正。

## 背景

### Refresh token rotation
PR #53 のレビュー指摘:
> Refresh token rotation/revocation methods are stubbed to \`return nil\`, which can allow refresh token replay and prevents proper revocation semantics.

### 設計バグの同時修正
fosite の \`CreateRefreshTokenSession\` は access_token を空文字で INSERT する refresh-only 行を作るが、現スキーマは \`access_token TEXT NOT NULL UNIQUE\` のため 2 件目で UNIQUE 違反する。Refresh フローが \`oidcc-refresh-token\` test で expected-skips になっていたため発覚していなかった。

## 変更

- \`db/schema.sql\`: \`tokens.access_token\` を NULL 許可。\`CHECK (access_token IS NOT NULL OR refresh_token IS NOT NULL)\` を追加
- \`internal/repository/token.go\`: AccessToken を \`sql.NullString\` で扱うよう更新
- \`internal/repository/oauth/token.go\`: \`RotateRefreshToken\` で signature 一致行を削除 (再使用時は \`ErrTokenNotFound\` → \`fosite.ErrNotFound\`)
- 自動生成: \`internal/repository/oidc/*\` (sqlc)

## 残課題 (Phase 2 で対応)
- 完全な OAuth 2.1 rotation chain (previous_token_id) は \`refresh_tokens\` テーブル分離後に実装。本 PR は基本 rotation のみ

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 成功 (確認済み)
- [ ] 後続 PR で \`expected-skips.json\` から \`oidcc-refresh-token\` を除去