### PR TITLE
security(oauth): 全クライアントに PKCE を強制 (OAuth 2.1)

### DIFF
--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -48,7 +48,7 @@ func newOAuthProvider(storage fosite.Storage, config OAuthProviderConfig, privat
 		ScopeStrategy:                  fosite.ExactScopeStrategy,
 		AudienceMatchingStrategy:       fosite.DefaultAudienceMatchingStrategy,
 		SendDebugMessagesToClients:     false,
-		EnforcePKCE:                    false,
+		EnforcePKCE:                    true,
 		EnforcePKCEForPublicClients:    true,
 		EnablePKCEPlainChallengeMethod: false,
 		AccessTokenIssuer:              config.Issuer,


### PR DESCRIPTION
## 概要

\`fosite.Config.EnforcePKCE\` を \`true\` に変更。Confidential client にも PKCE を強制する。

## 背景

PR #53 のレビュー指摘:
> PKCE is explicitly disabled (\`EnforcePKCE*\` false) even though the server exposes PKCE parameters and discovery advertises code_challenge methods.

OAuth 2.1 では client type に関わらず Authorization Code Grant の全ケースで PKCE 必須。OIDC discovery メタデータの \`code_challenge_methods_supported\` 表記とも整合する。

## 変更

- \`cmd/oauth.go\`: \`EnforcePKCE: false\` → \`true\`

## 後方互換性
- 既存 client が PKCE なしで認可リクエストすると 4xx エラーになる。本番投入前に各 RP 側の対応確認が必要

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 成功 (確認済み)