### PR TITLE
feat(oauth): request / request_uri パラメータを明示的に拒否し discovery に反映

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -612,6 +612,21 @@ components:
           type: array
           items:
             type: string
+        request_parameter_supported:
+          type: boolean
+          description: |
+            Indicates whether the OP supports use of the `request` parameter
+            (OpenID Connect Core 1.0 §6 / Discovery 1.0 §3).
+        request_uri_parameter_supported:
+          type: boolean
+          description: |
+            Indicates whether the OP supports use of the `request_uri` parameter
+            (OpenID Connect Core 1.0 §6 / Discovery 1.0 §3).
+        require_request_uri_registration:
+          type: boolean
+          description: |
+            Indicates whether the OP requires `request_uri` values to be
+            pre-registered (OpenID Connect Discovery 1.0 §3).
 
     JWKS:
       type: object

--- a/internal/router/v1/gen/models.go
+++ b/internal/router/v1/gen/models.go
@@ -228,6 +228,9 @@ type OpenIDConfiguration struct {
 	IdTokenSigningAlgValuesSupported  []string  `json:"id_token_signing_alg_values_supported"`
 	Issuer                            string    `json:"issuer"`
 	JwksUri                           string    `json:"jwks_uri"`
+	RequestParameterSupported         *bool     `json:"request_parameter_supported,omitempty"`
+	RequestUriParameterSupported      *bool     `json:"request_uri_parameter_supported,omitempty"`
+	RequireRequestUriRegistration     *bool     `json:"require_request_uri_registration,omitempty"`
 	ResponseTypesSupported            []string  `json:"response_types_supported"`
 	ScopesSupported                   *[]string `json:"scopes_supported,omitempty"`
 	SubjectTypesSupported             []string  `json:"subject_types_supported"`

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -33,6 +33,23 @@ func (h *Handler) authorize(ctx *echo.Context) error {
 	rw := ctx.Response()
 	req := ctx.Request()
 
+	// Discovery advertises request_parameter_supported=false and
+	// request_uri_parameter_supported=false. OIDC Core 1.0 §6.1 requires the
+	// matching error codes (request_not_supported / request_uri_not_supported)
+	// when these parameters are sent regardless. Without this short-circuit
+	// fosite would otherwise try to parse the JWT request object and surface
+	// invalid_request_object instead.
+	if err := req.ParseForm(); err == nil {
+		if req.Form.Get("request") != "" {
+			h.oauth2.WriteAuthorizeError(c, rw, &fosite.AuthorizeRequest{Request: fosite.Request{Form: req.Form}}, fosite.ErrRequestNotSupported)
+			return nil
+		}
+		if req.Form.Get("request_uri") != "" {
+			h.oauth2.WriteAuthorizeError(c, rw, &fosite.AuthorizeRequest{Request: fosite.Request{Form: req.Form}}, fosite.ErrRequestURINotSupported)
+			return nil
+		}
+	}
+
 	ar, err := h.oauth2.NewAuthorizeRequest(c, req)
 	if err != nil {
 		h.oauth2.WriteAuthorizeError(c, rw, ar, err)
@@ -269,6 +286,8 @@ func (h *Handler) GetOpenIDConfiguration(ctx *echo.Context) error {
 	claimsSupported := []string{"sub", "name", "preferred_username", "email", "email_verified"}
 	codeChallengeMethodsSupported := []string{"S256", "plain"}
 	tokenEndpointAuthMethodsSupported := []string{"client_secret_basic", "client_secret_post"}
+	requestParameterSupported := false
+	requestURIParameterSupported := false
 
 	return ctx.JSON(http.StatusOK, gen.OpenIDConfiguration{
 		Issuer:                            issuer,
@@ -283,5 +302,7 @@ func (h *Handler) GetOpenIDConfiguration(ctx *echo.Context) error {
 		ClaimsSupported:                   &claimsSupported,
 		CodeChallengeMethodsSupported:     &codeChallengeMethodsSupported,
 		TokenEndpointAuthMethodsSupported: &tokenEndpointAuthMethodsSupported,
+		RequestParameterSupported:         &requestParameterSupported,
+		RequestUriParameterSupported:      &requestURIParameterSupported,
 	})
 }


### PR DESCRIPTION
## 概要

\`request\` / \`request_uri\` パラメータが渡された場合に \`request_not_supported\` / \`request_uri_not_supported\` エラーを返す。OIDC Discovery でも \`request_parameter_supported: false\` / \`request_uri_parameter_supported: false\` を明示。

## 背景

PR #128 と組み合わせて \`oidcc-unsigned-request-object-supported-correctly-or-rejected-as-unsupported\` および \`oidcc-ensure-request-object-with-redirect-uri\` の expected-skips を解消する目的。

fosite はデフォルトで \`request\` パラメータを JWT としてパースしようとし、失敗すると \`invalid_request_object\` を返す。OIDC Core 1.0 §6.1 が要求するエラーコードは \`request_not_supported\` / \`request_uri_not_supported\` なので、handler 先頭で短絡して仕様準拠のエラーを返す。

## 変更

### 1. \`internal/router/v1/oauth.go\`
- \`authorize\` handler の冒頭で \`request\` / \`request_uri\` パラメータの存在を検査し、\`fosite.ErrRequestNotSupported\` / \`fosite.ErrRequestURINotSupported\` を返す
- \`GetOpenIDConfiguration\` で \`RequestParameterSupported = false\` / \`RequestUriParameterSupported = false\` を返す

### 2. \`api/openapi.yaml\`
- \`OpenIDConfiguration\` schema に \`request_parameter_supported\` / \`request_uri_parameter_supported\` / \`require_request_uri_registration\` を追加

### 3. \`internal/router/v1/gen/models.go\`
- 上記フィールドを手動追加。\`server.go\` は再生成すると Echo v5 パッチが消えるため、\`models.go\` の対応行のみ手動で反映

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| Request Object エラーコード | OIDC Core 1.0 | [§6.1](https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests) |
| \`request_parameter_supported\` / \`request_uri_parameter_supported\` | OIDC Discovery 1.0 | [§3](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata) |

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)

## 後続 PR
- expected-skips.json の整理 (Phase 1.11)