### PR TITLE
feat(oauth): /.well-known/oauth-authorization-server エンドポイント追加 (RFC 8414)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -170,6 +170,25 @@ paths:
               schema:
                 $ref: "#/components/schemas/JWKS"
 
+  /.well-known/oauth-authorization-server:
+    get:
+      operationId: getOAuthAuthorizationServerMetadata
+      summary: OAuth 2.0 Authorization Server Metadata
+      description: |
+        RFC 8414 のメタデータを返却。OAuth 2.1 / 2.0 クライアントが
+        endpoint discovery に利用する。OIDC Discovery と一部フィールドを共有するが、
+        OIDC 専用 (id_token_signing_alg_values_supported, subject_types_supported, claims_supported) を
+        除き OAuth 専用 (revocation_endpoint, introspection_endpoint, response_modes_supported) を含む。
+      tags:
+        - discovery
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthAuthorizationServerMetadata"
+
   /oauth2/userinfo:
     get:
       operationId: getUserInfo
@@ -612,6 +631,76 @@ components:
           type: array
           items:
             type: string
+
+    OAuthAuthorizationServerMetadata:
+      type: object
+      description: |
+        RFC 8414 OAuth 2.0 Authorization Server Metadata.
+      required:
+        - issuer
+        - authorization_endpoint
+        - token_endpoint
+        - response_types_supported
+      properties:
+        issuer:
+          type: string
+          format: uri
+        authorization_endpoint:
+          type: string
+          format: uri
+        token_endpoint:
+          type: string
+          format: uri
+        jwks_uri:
+          type: string
+          format: uri
+        registration_endpoint:
+          type: string
+          format: uri
+          description: Dynamic Client Registration endpoint (RFC 7591)
+        revocation_endpoint:
+          type: string
+          format: uri
+          description: Token Revocation endpoint (RFC 7009)
+        introspection_endpoint:
+          type: string
+          format: uri
+          description: Token Introspection endpoint (RFC 7662)
+        scopes_supported:
+          type: array
+          items:
+            type: string
+        response_types_supported:
+          type: array
+          items:
+            type: string
+        response_modes_supported:
+          type: array
+          items:
+            type: string
+        grant_types_supported:
+          type: array
+          items:
+            type: string
+        token_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        revocation_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        introspection_endpoint_auth_methods_supported:
+          type: array
+          items:
+            type: string
+        code_challenge_methods_supported:
+          type: array
+          items:
+            type: string
+        service_documentation:
+          type: string
+          format: uri
 
     JWKS:
       type: object

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.GET("/.well-known/oauth-authorization-server", handler.GetOAuthAuthorizationServerMetadata)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,9 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	// TODO: drop this manual registration once oapi-codegen v3 ships proper Echo v5
+	// support and we regenerate server.go — gen.RegisterHandlers will then bind the
+	// route itself and Echo will panic on the duplicate.
 	e.GET("/.well-known/oauth-authorization-server", handler.GetOAuthAuthorizationServerMetadata)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)

--- a/internal/router/v1/gen/models.go
+++ b/internal/router/v1/gen/models.go
@@ -220,6 +220,28 @@ type OAuthError struct {
 // OAuthErrorError defines model for OAuthError.Error.
 type OAuthErrorError string
 
+// OAuthAuthorizationServerMetadata defines model for OAuthAuthorizationServerMetadata
+// per RFC 8414. Includes OAuth-specific fields not present in OIDC discovery
+// (revocation_endpoint, introspection_endpoint, response_modes_supported, etc.).
+type OAuthAuthorizationServerMetadata struct {
+	AuthorizationEndpoint                      string    `json:"authorization_endpoint"`
+	CodeChallengeMethodsSupported              *[]string `json:"code_challenge_methods_supported,omitempty"`
+	GrantTypesSupported                        *[]string `json:"grant_types_supported,omitempty"`
+	IntrospectionEndpoint                      *string   `json:"introspection_endpoint,omitempty"`
+	IntrospectionEndpointAuthMethodsSupported  *[]string `json:"introspection_endpoint_auth_methods_supported,omitempty"`
+	Issuer                                     string    `json:"issuer"`
+	JwksUri                                    *string   `json:"jwks_uri,omitempty"`
+	RegistrationEndpoint                       *string   `json:"registration_endpoint,omitempty"`
+	ResponseModesSupported                     *[]string `json:"response_modes_supported,omitempty"`
+	ResponseTypesSupported                     []string  `json:"response_types_supported"`
+	RevocationEndpoint                         *string   `json:"revocation_endpoint,omitempty"`
+	RevocationEndpointAuthMethodsSupported     *[]string `json:"revocation_endpoint_auth_methods_supported,omitempty"`
+	ScopesSupported                            *[]string `json:"scopes_supported,omitempty"`
+	ServiceDocumentation                       *string   `json:"service_documentation,omitempty"`
+	TokenEndpoint                              string    `json:"token_endpoint"`
+	TokenEndpointAuthMethodsSupported          *[]string `json:"token_endpoint_auth_methods_supported,omitempty"`
+}
+
 // OpenIDConfiguration defines model for OpenIDConfiguration.
 type OpenIDConfiguration struct {
 	AuthorizationEndpoint             string    `json:"authorization_endpoint"`

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -285,3 +285,36 @@ func (h *Handler) GetOpenIDConfiguration(ctx *echo.Context) error {
 		TokenEndpointAuthMethodsSupported: &tokenEndpointAuthMethodsSupported,
 	})
 }
+
+// GetOAuthAuthorizationServerMetadata serves the RFC 8414 metadata document.
+// Compared to OIDC discovery this strips OIDC-only fields (subject_types_supported,
+// id_token_signing_alg_values_supported, claims_supported) and adds OAuth-only ones
+// (response_modes_supported, grant_types_supported).
+//
+// Refs:
+//   - RFC 8414 §2 (Authorization Server Metadata)
+//     https://datatracker.ietf.org/doc/html/rfc8414#section-2
+//   - RFC 8414 §3.1 (.well-known/oauth-authorization-server)
+//     https://datatracker.ietf.org/doc/html/rfc8414#section-3.1
+func (h *Handler) GetOAuthAuthorizationServerMetadata(ctx *echo.Context) error {
+	issuer := strings.TrimRight(h.config.Issuer, "/")
+	jwksURI := issuer + "/.well-known/jwks.json"
+	scopesSupported := []string{"openid", "profile", "email"}
+	grantTypesSupported := []string{"authorization_code", "refresh_token"}
+	responseModesSupported := []string{"query"}
+	codeChallengeMethodsSupported := []string{"S256", "plain"}
+	tokenEndpointAuthMethodsSupported := []string{"client_secret_basic", "client_secret_post"}
+
+	return ctx.JSON(http.StatusOK, gen.OAuthAuthorizationServerMetadata{
+		Issuer:                            issuer,
+		AuthorizationEndpoint:             issuer + "/oauth2/authorize",
+		TokenEndpoint:                     issuer + "/oauth2/token",
+		JwksUri:                           &jwksURI,
+		ResponseTypesSupported:            []string{"code"},
+		ResponseModesSupported:            &responseModesSupported,
+		GrantTypesSupported:               &grantTypesSupported,
+		ScopesSupported:                   &scopesSupported,
+		CodeChallengeMethodsSupported:     &codeChallengeMethodsSupported,
+		TokenEndpointAuthMethodsSupported: &tokenEndpointAuthMethodsSupported,
+	})
+}

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -267,7 +267,9 @@ func (h *Handler) GetOpenIDConfiguration(ctx *echo.Context) error {
 	issuer := strings.TrimRight(h.config.Issuer, "/")
 	scopesSupported := []string{"openid", "profile", "email"}
 	claimsSupported := []string{"sub", "name", "preferred_username", "email", "email_verified"}
-	codeChallengeMethodsSupported := []string{"S256", "plain"}
+	// OAuth 2.1 §1.4.2 / fosite EnablePKCEPlainChallengeMethod=false: only S256 is
+	// honoured by the server, so advertising "plain" would only invite downgrades.
+	codeChallengeMethodsSupported := []string{"S256"}
 	tokenEndpointAuthMethodsSupported := []string{"client_secret_basic", "client_secret_post"}
 
 	return ctx.JSON(http.StatusOK, gen.OpenIDConfiguration{
@@ -302,7 +304,12 @@ func (h *Handler) GetOAuthAuthorizationServerMetadata(ctx *echo.Context) error {
 	scopesSupported := []string{"openid", "profile", "email"}
 	grantTypesSupported := []string{"authorization_code", "refresh_token"}
 	responseModesSupported := []string{"query"}
-	codeChallengeMethodsSupported := []string{"S256", "plain"}
+	// OAuth 2.1 (draft) §1.4.2: clients SHOULD use a code_challenge method that
+	// does not expose the verifier in the authorization request, and S256 is the
+	// only such method. fosite is configured with EnablePKCEPlainChallengeMethod=false
+	// in cmd/oauth.go so the server never accepts "plain" anyway; advertising it
+	// here would only invite downgrade attempts.
+	codeChallengeMethodsSupported := []string{"S256"}
 	tokenEndpointAuthMethodsSupported := []string{"client_secret_basic", "client_secret_post"}
 
 	return ctx.JSON(http.StatusOK, gen.OAuthAuthorizationServerMetadata{


### PR DESCRIPTION
## 概要

OAuth 2.0 Authorization Server Metadata エンドポイントを追加。OIDC Discovery と並んで OAuth 2.1 クライアントが利用するメタデータを公開する。

## 背景

traPortal v2 仕様の Metadata セクションで定義:
| メソッド | パス | 説明 |
| -------- | ----------------------------------------- | -------------------- |
| GET | \`/.well-known/openid-configuration\` | OIDC Discovery (既存) |
| GET | \`/.well-known/jwks.json\` | 公開鍵セット (既存) |
| **GET** | **\`/.well-known/oauth-authorization-server\`** | **OAuth 2.1 メタデータ (本PR)** |

後続 PR (Phase 3.1 revoke / Phase 3.2 introspect / Phase 3.5 DCR / Phase 3.6 device flow) で対応エンドポイントを追加した際にメタデータも追記する前提。

## 変更

### 1. \`api/openapi.yaml\`
- \`/.well-known/oauth-authorization-server\` パス追加
- \`OAuthAuthorizationServerMetadata\` schema 追加 (RFC 8414 §2 全フィールド対応)

### 2. \`internal/router/v1/oauth.go\`
- \`GetOAuthAuthorizationServerMetadata\` handler 追加
- 現状の対応に合わせて \`response_types: ["code"]\`, \`response_modes: ["query"]\`, \`grant_types: ["authorization_code", "refresh_token"]\` を返却
- \`revocation_endpoint\` / \`introspection_endpoint\` は後続 PR で実装後に追加

### 3. \`cmd/serve.go\`
- ルート登録 (\`gen.RegisterHandlers\` を再生成すると Echo v5 patch が消えるため手動)

### 4. \`internal/router/v1/gen/models.go\`
- 上記 handler 用の構造体を手動追加

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| Authorization Server Metadata | RFC 8414 | [§2](https://datatracker.ietf.org/doc/html/rfc8414#section-2) |
| Well-Known URI | RFC 8414 | [§3.1](https://datatracker.ietf.org/doc/html/rfc8414#section-3.1) |

## テスト

- [ ] CI (Lint / Build / Test) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)
- [ ] 手動: \`curl http://localhost:8080/.well-known/oauth-authorization-server\` で正しい JSON が返る

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * OAuth 2.0 認可サーバーのメタデータ探索エンドポイントを追加しました。RFC 8414 に準拠し、発行者、認可エンドポイント、トークンエンドポイント、サポートされているレスポンスタイプなど、OAuth サーバーの設定情報が利用可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->