### PR TITLE
feat(oauth): /oauth2/revoke エンドポイント追加 (RFC 7009)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -342,6 +342,38 @@ paths:
               schema:
                 $ref: "#/components/schemas/OAuthError"
 
+  /oauth2/revoke:
+    post:
+      operationId: revokeToken
+      summary: トークン失効エンドポイント (RFC 7009)
+      description: |
+        指定された access_token または refresh_token を無効化する。
+        RFC 7009 §2.2 により認可されたクライアントによる呼び出しは、
+        トークンが既に存在しなかった場合でも 200 OK を返す。
+      tags:
+        - oauth2/oidc
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/RevokeRequest"
+      responses:
+        "200":
+          description: OK (トークンが無効化された / そもそも存在しなかった)
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+
 components:
   schemas:
     AuthorizeRequest:
@@ -512,6 +544,30 @@ components:
         code_verifier:
           type: string
           description: PKCE code_verifier
+
+    RevokeRequest:
+      type: object
+      description: |
+        RFC 7009 §2.1 トークン失効リクエスト。
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: 失効させる access_token または refresh_token
+        token_type_hint:
+          type: string
+          enum:
+            - access_token
+            - refresh_token
+          description: |
+            トークン種別ヒント (RFC 7009 §2.1)。
+            提供されると検索順序が最適化される。誤指定でも動作する。
+        client_id:
+          type: string
+          format: uuid
+        client_secret:
+          type: string
 
     TokenResponse:
       type: object

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.POST("/oauth2/revoke", handler.Revoke)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/internal/router/v1/gen/models.go
+++ b/internal/router/v1/gen/models.go
@@ -220,6 +220,23 @@ type OAuthError struct {
 // OAuthErrorError defines model for OAuthError.Error.
 type OAuthErrorError string
 
+// RevokeRequestTokenTypeHint defines model for RevokeRequest.TokenTypeHint.
+type RevokeRequestTokenTypeHint string
+
+// Defines values for RevokeRequestTokenTypeHint.
+const (
+	RevokeRequestTokenTypeHintAccessToken  RevokeRequestTokenTypeHint = "access_token"
+	RevokeRequestTokenTypeHintRefreshToken RevokeRequestTokenTypeHint = "refresh_token"
+)
+
+// RevokeRequest defines model for RevokeRequest (RFC 7009 §2.1).
+type RevokeRequest struct {
+	ClientId      *openapi_types.UUID         `json:"client_id,omitempty"`
+	ClientSecret  *string                     `json:"client_secret,omitempty"`
+	Token         string                      `json:"token"`
+	TokenTypeHint *RevokeRequestTokenTypeHint `json:"token_type_hint,omitempty"`
+}
+
 // OpenIDConfiguration defines model for OpenIDConfiguration.
 type OpenIDConfiguration struct {
 	AuthorizationEndpoint             string    `json:"authorization_endpoint"`

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -154,6 +154,26 @@ func parseMaxAge(ar fosite.AuthorizeRequester) (*int64, error) {
 	return &maxAge, nil
 }
 
+// Revoke implements RFC 7009 OAuth 2.0 Token Revocation. fosite already wires
+// the OAuth2TokenRevocationFactory into the provider, so the handler just
+// shuttles the request through and lets fosite emit the spec-correct response
+// (200 on success or no-op, 400/401 on invalid request / client auth).
+//
+// Refs:
+//   - RFC 7009 §2.1 (Revocation Request)
+//     https://datatracker.ietf.org/doc/html/rfc7009#section-2.1
+//   - RFC 7009 §2.2 (Revocation Response)
+//     https://datatracker.ietf.org/doc/html/rfc7009#section-2.2
+func (h *Handler) Revoke(ctx *echo.Context) error {
+	c := ctx.Request().Context()
+	rw := ctx.Response()
+	req := ctx.Request()
+
+	err := h.oauth2.NewRevocationRequest(c, req)
+	h.oauth2.WriteRevocationResponse(c, rw, err)
+	return nil
+}
+
 func (h *Handler) Token(ctx *echo.Context) error {
 	c := ctx.Request().Context()
 	rw := ctx.Response()


### PR DESCRIPTION
## 概要

OAuth 2.0 Token Revocation エンドポイントを追加。クライアントが access_token / refresh_token を明示的に失効できるようにする。

## 背景

traPortal v2 仕様の OAuth 2.1 / OIDC セクション:
| メソッド | パス | 説明 |
| -------- | --------------------- | --------------------------------------- |
| POST | **\`/oauth2/revoke\`** | **トークン失効 (RFC 7009)** ← 本PR |

fosite には \`OAuth2TokenRevocationFactory\` が既に \`cmd/oauth.go\` で wire 済みのため、handler を新設して既存 storage 経由で動作する。

## 変更

### 1. \`api/openapi.yaml\`
- \`/oauth2/revoke\` POST パス追加
- \`RevokeRequest\` schema 追加 (RFC 7009 §2.1)

### 2. \`internal/router/v1/oauth.go\`
- \`Revoke\` handler 追加。fosite の \`NewRevocationRequest\` / \`WriteRevocationResponse\` を呼び出すだけ

### 3. \`cmd/serve.go\`
- ルート登録 (Echo v5 patch を保つため手動)

### 4. \`internal/router/v1/gen/models.go\`
- \`RevokeRequest\` 構造体を手動追加

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| Token Revocation Request | RFC 7009 | [§2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) |
| Token Revocation Response | RFC 7009 | [§2.2](https://datatracker.ietf.org/doc/html/rfc7009#section-2.2) |

## 後続 PR
- \`/.well-known/oauth-authorization-server\` (#131) と OIDC Discovery で \`revocation_endpoint\` を advertise

## テスト

- [ ] CI (Lint / Build / Test) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)
- [ ] 手動: 発行済みトークンに対して \`curl -X POST -d 'token=xxx&token_type_hint=access_token'\` で 200 を確認、その後 \`/userinfo\` が 401 になること