### PR TITLE
feat(oauth): /oauth2/introspect エンドポイント追加 (RFC 7662)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -170,6 +170,42 @@ paths:
               schema:
                 $ref: "#/components/schemas/JWKS"
 
+  /oauth2/introspect:
+    post:
+      operationId: introspectToken
+      summary: トークンイントロスペクションエンドポイント (RFC 7662)
+      description: |
+        提示された access_token / refresh_token のメタデータを返却。
+        active=false でアクティブでないことを示し、スコープ・有効期限・
+        ユーザー識別子等を返す。クライアント認証必須。
+      tags:
+        - oauth2/oidc
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/IntrospectRequest"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IntrospectResponse"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+
   /oauth2/userinfo:
     get:
       operationId: getUserInfo
@@ -512,6 +548,75 @@ components:
         code_verifier:
           type: string
           description: PKCE code_verifier
+
+    IntrospectRequest:
+      type: object
+      description: |
+        RFC 7662 §2.1 トークンイントロスペクションリクエスト。
+      required:
+        - token
+      properties:
+        token:
+          type: string
+          description: イントロスペクション対象のトークン
+        token_type_hint:
+          type: string
+          enum:
+            - access_token
+            - refresh_token
+          description: トークン種別ヒント (RFC 7662 §2.1)
+        client_id:
+          type: string
+          format: uuid
+        client_secret:
+          type: string
+
+    IntrospectResponse:
+      type: object
+      description: |
+        RFC 7662 §2.2 トークンイントロスペクションレスポンス。
+        active=false の場合、他のフィールドは省略可能。
+      required:
+        - active
+      properties:
+        active:
+          type: boolean
+          description: トークンがアクティブか (RFC 7662 §2.2)
+        scope:
+          type: string
+          description: スペース区切りのスコープ
+        client_id:
+          type: string
+        username:
+          type: string
+        token_type:
+          type: string
+          description: 例 Bearer
+        exp:
+          type: integer
+          format: int64
+          description: トークン有効期限 (Unix epoch)
+        iat:
+          type: integer
+          format: int64
+          description: 発行時刻 (Unix epoch)
+        nbf:
+          type: integer
+          format: int64
+          description: 有効開始時刻 (Unix epoch)
+        sub:
+          type: string
+          description: トークンサブジェクト (ユーザーID等)
+        aud:
+          type: array
+          items:
+            type: string
+        iss:
+          type: string
+          description: 発行者 URL
+        jti:
+          type: string
+          description: JWT ID
 
     TokenResponse:
       type: object

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.POST("/oauth2/introspect", handler.Introspect)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/internal/router/v1/gen/models.go
+++ b/internal/router/v1/gen/models.go
@@ -220,6 +220,39 @@ type OAuthError struct {
 // OAuthErrorError defines model for OAuthError.Error.
 type OAuthErrorError string
 
+// IntrospectRequestTokenTypeHint defines model for IntrospectRequest.TokenTypeHint.
+type IntrospectRequestTokenTypeHint string
+
+// Defines values for IntrospectRequestTokenTypeHint.
+const (
+	IntrospectRequestTokenTypeHintAccessToken  IntrospectRequestTokenTypeHint = "access_token"
+	IntrospectRequestTokenTypeHintRefreshToken IntrospectRequestTokenTypeHint = "refresh_token"
+)
+
+// IntrospectRequest defines model for IntrospectRequest (RFC 7662 §2.1).
+type IntrospectRequest struct {
+	ClientId      *openapi_types.UUID             `json:"client_id,omitempty"`
+	ClientSecret  *string                         `json:"client_secret,omitempty"`
+	Token         string                          `json:"token"`
+	TokenTypeHint *IntrospectRequestTokenTypeHint `json:"token_type_hint,omitempty"`
+}
+
+// IntrospectResponse defines model for IntrospectResponse (RFC 7662 §2.2).
+type IntrospectResponse struct {
+	Active    bool      `json:"active"`
+	Aud       *[]string `json:"aud,omitempty"`
+	ClientId  *string   `json:"client_id,omitempty"`
+	Exp       *int64    `json:"exp,omitempty"`
+	Iat       *int64    `json:"iat,omitempty"`
+	Iss       *string   `json:"iss,omitempty"`
+	Jti       *string   `json:"jti,omitempty"`
+	Nbf       *int64    `json:"nbf,omitempty"`
+	Scope     *string   `json:"scope,omitempty"`
+	Sub       *string   `json:"sub,omitempty"`
+	TokenType *string   `json:"token_type,omitempty"`
+	Username  *string   `json:"username,omitempty"`
+}
+
 // OpenIDConfiguration defines model for OpenIDConfiguration.
 type OpenIDConfiguration struct {
 	AuthorizationEndpoint             string    `json:"authorization_endpoint"`

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -180,6 +180,31 @@ func (h *Handler) Token(ctx *echo.Context) error {
 	return nil
 }
 
+// Introspect implements RFC 7662 OAuth 2.0 Token Introspection. fosite already
+// wires OAuth2TokenIntrospectionFactory into the provider; the handler shapes
+// the request and writes whatever fosite returns. Per RFC 7662 §2.2, an
+// inactive or unknown token still yields HTTP 200 with {"active": false}.
+//
+// Refs:
+//   - RFC 7662 §2.1 (Introspection Request)
+//     https://datatracker.ietf.org/doc/html/rfc7662#section-2.1
+//   - RFC 7662 §2.2 (Introspection Response)
+//     https://datatracker.ietf.org/doc/html/rfc7662#section-2.2
+func (h *Handler) Introspect(ctx *echo.Context) error {
+	c := ctx.Request().Context()
+	rw := ctx.Response()
+	req := ctx.Request()
+
+	resp, err := h.oauth2.NewIntrospectionRequest(c, req, oauth.NewSession("", time.Time{}))
+	if err != nil {
+		h.oauth2.WriteIntrospectionError(c, rw, err)
+		return nil
+	}
+
+	h.oauth2.WriteIntrospectionResponse(c, rw, resp)
+	return nil
+}
+
 func (h *Handler) GetUserInfo(ctx *echo.Context) error {
 	token, err := h.extractBearerToken(ctx)
 	if err != nil {


### PR DESCRIPTION
## 概要

OAuth 2.0 Token Introspection エンドポイントを公開。RP がトークンの有効性・スコープ・サブジェクト等を検証できる。

## 背景

traPortal v2 仕様で各 RP が \`/oauth2/introspect\` でトークン検証する設計。fosite には \`OAuth2TokenIntrospectionFactory\` が既に \`cmd/oauth.go\` で wire 済み。OP 内部ではすでに \`/userinfo\` 実装で \`IntrospectToken\` を利用しているが、外部公開エンドポイントが無かった。

## 変更

### 1. \`api/openapi.yaml\`
- \`/oauth2/introspect\` POST パス追加
- \`IntrospectRequest\` schema 追加 (RFC 7662 §2.1)
- \`IntrospectResponse\` schema 追加 (RFC 7662 §2.2 全フィールド)

### 2. \`internal/router/v1/oauth.go\`
- \`Introspect\` handler 追加。fosite の \`NewIntrospectionRequest\` / \`WriteIntrospectionResponse\` を呼び出し

### 3. \`cmd/serve.go\`
- ルート登録 (Echo v5 patch を保つため手動)

### 4. \`internal/router/v1/gen/models.go\`
- 上記 schema の Go struct を手動追加

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| Introspection Request | RFC 7662 | [§2.1](https://datatracker.ietf.org/doc/html/rfc7662#section-2.1) |
| Introspection Response | RFC 7662 | [§2.2](https://datatracker.ietf.org/doc/html/rfc7662#section-2.2) |

## 後続 PR
- \`/.well-known/oauth-authorization-server\` (#131) で \`introspection_endpoint\` を advertise

## テスト

- [ ] CI (Lint / Build / Test) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)
- [ ] 手動: 有効トークンに対して \`{"active": true, "sub": ..., "scope": ...}\` が返ること
- [ ] 手動: 失効済みトークンに対して \`{"active": false}\` が返ること