### PR TITLE
feat(oauth): /oauth2/logout エンドポイント追加 (OIDC RP-Initiated Logout 1.0)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -170,6 +170,61 @@ paths:
               schema:
                 $ref: "#/components/schemas/JWKS"
 
+  /oauth2/logout:
+    get:
+      operationId: getRPInitiatedLogout
+      summary: RP-Initiated Logout (OpenID Connect)
+      description: |
+        OpenID Connect RP-Initiated Logout 1.0 のエンドユーザーセッション終了
+        エンドポイント。id_token_hint を検証してセッションを破棄し、
+        クライアントが事前登録した post_logout_redirect_uri へリダイレクトする。
+      tags:
+        - oauth2/oidc
+      parameters:
+        - name: id_token_hint
+          in: query
+          required: false
+          schema:
+            type: string
+          description: |
+            事前に発行された ID Token (検証用)。OIDC Core 1.0 の
+            id_token_hint と同じ形式。
+        - name: post_logout_redirect_uri
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uri
+          description: |
+            ログアウト後のリダイレクト先。client が事前登録した URI と
+            完全一致する必要がある。
+        - name: client_id
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: |
+            id_token_hint が無いがリダイレクト URI を指定したい場合に必須。
+        - name: state
+          in: query
+          required: false
+          schema:
+            type: string
+          description: post_logout_redirect_uri 戻り時に echo back される
+        - name: ui_locales
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "302":
+          description: ログアウト完了 → post_logout_redirect_uri (登録済みの場合)
+        "200":
+          description: ログアウト完了確認ページ (post_logout_redirect_uri 無し / 未登録時)
+        "400":
+          description: Bad Request (id_token_hint 不正等)
+
   /oauth2/userinfo:
     get:
       operationId: getUserInfo

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.GET("/oauth2/logout", handler.RPInitiatedLogout)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/internal/router/v1/auth.go
+++ b/internal/router/v1/auth.go
@@ -8,10 +8,17 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-jose/go-jose/v4"
 	"github.com/labstack/echo/v5"
 
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
+
+// idTokenSignatureAlgorithms lists the signing algorithms accepted on
+// id_token_hint. Mirrors id_token_signing_alg_values_supported in discovery
+// (currently RS256 only). go-jose v4 requires the caller to declare the
+// expected algorithms up-front to prevent algorithm-substitution attacks.
+var idTokenSignatureAlgorithms = []jose.SignatureAlgorithm{jose.RS256}
 
 const sessionName = "oidc_session"
 
@@ -114,6 +121,74 @@ func (h *Handler) authenticatePortalUser(ctx *echo.Context, trapID, password str
 }
 
 func (h *Handler) Logout(ctx *echo.Context) error {
+	if err := h.clearSession(ctx); err != nil {
+		return err
+	}
+	return ctx.Redirect(http.StatusFound, "/")
+}
+
+// RPInitiatedLogout implements OpenID Connect RP-Initiated Logout 1.0.
+//
+// Steps:
+//  1. Verify id_token_hint signature (if provided) using the OP's signing key.
+//  2. Terminate the End-User's session at the OP.
+//  3. If post_logout_redirect_uri was supplied AND it matches a URI registered
+//     for the client identified by id_token_hint.aud (or the explicit client_id
+//     query parameter), redirect there with the optional state echoed back.
+//  4. Otherwise render a simple confirmation page.
+//
+// post_logout_redirect_uri validation is intentionally strict: clients without
+// a pre-registered URI are not redirected to arbitrary external locations,
+// matching the open-redirect mitigation in the spec. The clients table does
+// not yet carry post_logout_uris (Phase 2.1), so for now any external URI is
+// rejected and the confirmation page is shown.
+//
+// Refs:
+//   - OpenID Connect RP-Initiated Logout 1.0 §2 (Logout Request)
+//     https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout
+//   - OpenID Connect RP-Initiated Logout 1.0 §3 (Redirect URI Validation)
+//     https://openid.net/specs/openid-connect-rpinitiated-1_0.html#ValidationAndErrorHandling
+func (h *Handler) RPInitiatedLogout(ctx *echo.Context) error {
+	idTokenHint := ctx.QueryParam("id_token_hint")
+	postLogoutRedirectURI := ctx.QueryParam("post_logout_redirect_uri")
+	state := ctx.QueryParam("state")
+
+	if idTokenHint != "" && h.config.PrivateKey != nil {
+		// RP-Initiated Logout 1.0 §2: verify the supplied ID Token signature.
+		// Expired tokens are tolerated because §3 explicitly allows the OP to
+		// terminate the session even when the hint cannot be authoritatively
+		// validated as a current credential.
+		jws, err := jose.ParseSigned(idTokenHint, idTokenSignatureAlgorithms)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid id_token_hint")
+		}
+		if _, err := jws.Verify(&h.config.PrivateKey.PublicKey); err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid id_token_hint signature")
+		}
+	}
+
+	if err := h.clearSession(ctx); err != nil {
+		return err
+	}
+
+	if postLogoutRedirectURI != "" {
+		// TODO(Phase 2.1): once clients.post_logout_uris is added, look up the
+		// client by id_token_hint.aud or client_id and verify exact match here.
+		// For now we always render the confirmation page to avoid open redirects.
+		_ = state
+	}
+
+	return ctx.HTML(http.StatusOK, `<!DOCTYPE html>
+<html>
+<head><title>Logged out</title></head>
+<body>
+    <h1>Logged out</h1>
+    <p>You have been signed out.</p>
+</body>
+</html>`)
+}
+
+func (h *Handler) clearSession(ctx *echo.Context) error {
 	session, err := h.sessions.Get(ctx.Request(), sessionName)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get session")
@@ -126,8 +201,7 @@ func (h *Handler) Logout(ctx *echo.Context) error {
 	if err := session.Save(ctx.Request(), ctx.Response()); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save session")
 	}
-
-	return ctx.Redirect(http.StatusFound, "/")
+	return nil
 }
 
 func sanitizeReturnURL(raw string) string {


### PR DESCRIPTION
## 概要

OpenID Connect RP-Initiated Logout 1.0 エンドポイントを \`/oauth2/logout\` に追加。RP からの End-User セッション終了リクエストを処理する。

## 背景

traPortal v2 仕様の OAuth 2.1 / OIDC セクション:
| メソッド | パス | 説明 |
| -------- | ---------------- | ------------------------------ |
| GET | **\`/oauth2/logout\`** | **ログアウト (RP-Initiated)** ← 本PR |

既存の \`/logout\` は単純なセッションクリアのみ。OIDC 仕様準拠の RP-Initiated Logout は別エンドポイントとして実装する。

## 変更

### 1. \`api/openapi.yaml\`
- \`/oauth2/logout\` GET パス追加
- パラメータ: \`id_token_hint\`, \`post_logout_redirect_uri\`, \`client_id\`, \`state\`, \`ui_locales\`

### 2. \`internal/router/v1/auth.go\`
- \`RPInitiatedLogout\` handler 追加
- id_token_hint の署名検証 (go-jose v4 で discovery 公開アルゴ \`RS256\` のみ受理)
- セッションクリア後、確認ページを表示
- 既存 \`Logout\` を \`clearSession\` ヘルパーへリファクタ

### 3. \`cmd/serve.go\`
- ルート登録 (Echo v5 patch を保つため手動)

## 制限事項 (本 PR では未対応)

- **post_logout_redirect_uri リダイレクトは無効化中**
  - 仕様 §3 で「事前登録必須」だが clients テーブルに \`post_logout_uris\` カラムが無い (Phase 2.1 で追加予定)
  - 安全側に倒し、提供された場合でも常に確認ページ表示
  - Phase 2.1 完了後の follow-up PR で正式対応
- end_session_endpoint の OIDC Discovery 広告も Phase 2.1 後

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| Logout Request | OIDC RP-Initiated Logout 1.0 | [§2](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#RPLogout) |
| Redirect URI Validation | OIDC RP-Initiated Logout 1.0 | [§3](https://openid.net/specs/openid-connect-rpinitiated-1_0.html#ValidationAndErrorHandling) |
| Algorithm pinning (alg=none mitigation) | RFC 8725 | [§3.1](https://datatracker.ietf.org/doc/html/rfc8725#section-3.1) |

## テスト

- [ ] CI (Lint / Build / Test) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)
- [ ] 手動: 有効な id_token_hint で confirmation page が表示
- [ ] 手動: 不正署名の id_token_hint で 400 が返る