### PR TITLE
feat(keys): signing_keys テーブル + key rotation 対応の keymanager 導入

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -62,11 +62,6 @@ jobs:
       - name: Build portal-oidc
         run: go build -o portal-oidc ./cmd/
 
-      - name: Generate RSA key
-        run: |
-          mkdir -p data
-          openssl genpkey -algorithm RSA -out data/private.pem -pkeyopt rsa_keygen_bits:2048
-
       - name: Start portal-oidc
         run: |
           ./portal-oidc serve > /tmp/portal-oidc.log 2>&1 &

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -34,7 +34,6 @@ type DatabaseConfig struct {
 
 type OAuthConfig struct {
 	Secret     string `koanf:"secret"` // #nosec G117 -- config struct, not serialized
-	KeyFile    string `koanf:"key_file"`
 	TestUserID string `koanf:"test_user_id"`
 }
 
@@ -54,7 +53,6 @@ var defaults = map[string]any{
 	"portal.database.name":     "portal",
 	"portal.database.sslmode":  "disable",
 	"oauth.secret":             "my-super-secret-signing-key-32!!",
-	"oauth.key_file":           "data/private.pem",
 	"oauth.test_user_id":       "00000000-0000-0000-0000-000000000000",
 }
 

--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -2,20 +2,13 @@ package main
 
 import (
 	"context"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"encoding/pem"
-	"errors"
-	"fmt"
-	"io"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/token/jwt"
+
+	"github.com/traPtitech/portal-oidc/internal/keymanager"
 )
 
 type OAuthProviderConfig struct {
@@ -38,7 +31,7 @@ func defaultOAuthProviderConfig() OAuthProviderConfig {
 	}
 }
 
-func newOAuthProvider(storage fosite.Storage, config OAuthProviderConfig, privateKey *rsa.PrivateKey) fosite.OAuth2Provider {
+func newOAuthProvider(storage fosite.Storage, config OAuthProviderConfig, keys *keymanager.Manager) fosite.OAuth2Provider {
 	fositeConfig := &fosite.Config{
 		AccessTokenLifespan:            config.AccessTokenLifespan,
 		RefreshTokenLifespan:           config.RefreshTokenLifespan,
@@ -55,8 +48,14 @@ func newOAuthProvider(storage fosite.Storage, config OAuthProviderConfig, privat
 		IDTokenIssuer:                  config.Issuer,
 	}
 
+	// Resolve the active signing key on every request so a manual rotation via
+	// the keymanager is picked up without restarting fosite.
 	privateKeyGetter := func(_ context.Context) (interface{}, error) {
-		return privateKey, nil
+		key, _, err := keys.ActiveKey()
+		if err != nil {
+			return nil, err
+		}
+		return key, nil
 	}
 
 	return compose.Compose(
@@ -76,130 +75,4 @@ func newOAuthProvider(storage fosite.Storage, config OAuthProviderConfig, privat
 		compose.OpenIDConnectExplicitFactory,
 		compose.OpenIDConnectRefreshFactory,
 	)
-}
-
-func loadOrGenerateKey(path string) (*rsa.PrivateKey, error) {
-	key, err := loadKey(path)
-	if err == nil {
-		return key, nil
-	}
-
-	if !errors.Is(err, os.ErrNotExist) {
-		return nil, err
-	}
-
-	key, err = rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := saveKey(path, key); err != nil {
-		return nil, err
-	}
-
-	return key, nil
-}
-
-func loadKey(path string) (key *rsa.PrivateKey, err error) {
-	root, filename, err := openKeyRoot(path)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if cerr := root.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	f, err := root.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	data, err := io.ReadAll(f)
-	if err != nil {
-		return nil, err
-	}
-
-	block, _ := pem.Decode(data)
-	if block == nil {
-		return nil, errors.New("failed to decode PEM")
-	}
-
-	switch block.Type {
-	case "RSA PRIVATE KEY":
-		return x509.ParsePKCS1PrivateKey(block.Bytes)
-	case "PRIVATE KEY":
-		parsed, pkcs8Err := x509.ParsePKCS8PrivateKey(block.Bytes)
-		if pkcs8Err != nil {
-			return nil, pkcs8Err
-		}
-		rsaKey, ok := parsed.(*rsa.PrivateKey)
-		if !ok {
-			return nil, errors.New("private key is not RSA")
-		}
-		return rsaKey, nil
-	default:
-		return nil, fmt.Errorf("unsupported PEM type: %s", block.Type)
-	}
-}
-
-func openKeyRoot(path string) (*os.Root, string, error) {
-	cleanPath := filepath.Clean(path)
-	dir := filepath.Dir(cleanPath)
-	filename := filepath.Base(cleanPath)
-
-	root, err := os.OpenRoot(dir)
-	if err != nil {
-		return nil, "", err
-	}
-
-	return root, filename, nil
-}
-
-func saveKey(path string, key *rsa.PrivateKey) (err error) {
-	cleanPath := filepath.Clean(path)
-	dir := filepath.Dir(cleanPath)
-	filename := filepath.Base(cleanPath)
-
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return err
-	}
-
-	root, err := os.OpenRoot(dir)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := root.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	data := pem.EncodeToMemory(&pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(key),
-	})
-
-	f, err := root.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if cerr := f.Close(); cerr != nil && err == nil {
-			err = cerr
-		}
-	}()
-
-	if err := f.Chmod(0o600); err != nil {
-		return err
-	}
-
-	_, err = f.Write(data)
-	return err
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/labstack/echo/v5/middleware"
 
+	"github.com/traPtitech/portal-oidc/internal/keymanager"
 	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
@@ -28,9 +29,9 @@ func newServer(cfg Config) (http.Handler, error) {
 		return nil, err
 	}
 
-	privateKey, err := loadOrGenerateKey(cfg.OAuth.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to load/generate RSA key: %w", err)
+	keys := keymanager.New(repository.NewSigningKeyRepository(queries))
+	if err := keys.EnsureActiveKey(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to ensure active signing key: %w", err)
 	}
 
 	clientRepo := repository.NewClientRepository(queries)
@@ -50,7 +51,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AuthCodeLifespan:     defaults.AuthCodeLifespan,
 		IDTokenLifespan:      defaults.IDTokenLifespan,
 		Secret:               []byte(cfg.OAuth.Secret),
-	}, privateKey)
+	}, keys)
 
 	var userUseCase usecase.UserUseCase
 	if cfg.Environment == "production" {
@@ -65,10 +66,10 @@ func newServer(cfg Config) (http.Handler, error) {
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
 		userUseCase,
+		keys,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),
-			PrivateKey:    privateKey,
 			Environment:   cfg.Environment,
 			TestUserID:    cfg.OAuth.TestUserID,
 		},

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,44 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- Signing key queries
+
+-- name: CreateSigningKey :exec
+INSERT INTO signing_keys (
+    id,
+    kid,
+    algorithm,
+    use_,
+    status,
+    public_key,
+    private_key,
+    expires_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+
+-- name: GetSigningKey :one
+SELECT * FROM signing_keys WHERE id = $1;
+
+-- name: GetSigningKeyByKID :one
+SELECT * FROM signing_keys WHERE kid = $1;
+
+-- name: GetActiveSigningKey :one
+SELECT * FROM signing_keys
+WHERE status = 'active' AND use_ = 'sig'
+ORDER BY created_at DESC
+LIMIT 1;
+
+-- name: ListPublishableSigningKeys :many
+SELECT * FROM signing_keys
+WHERE status IN ('active', 'rotated')
+ORDER BY created_at DESC;
+
+-- name: MarkSigningKeyRotated :exec
+UPDATE signing_keys
+SET status = 'rotated', rotated_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND status = 'active';
+
+-- name: RevokeSigningKey :exec
+UPDATE signing_keys
+SET status = 'revoked'
+WHERE id = $1;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,26 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §signing_keys
+-- JWT signing key material with rotation support. The active key is used to
+-- sign newly-issued tokens; rotated keys remain in JWKS so previously-issued
+-- tokens stay verifiable until they expire; revoked keys are removed entirely.
+CREATE TABLE IF NOT EXISTS signing_keys (
+  id UUID NOT NULL,
+  kid TEXT NOT NULL,
+  algorithm TEXT NOT NULL,
+  use_ TEXT NOT NULL DEFAULT 'sig',
+  status TEXT NOT NULL DEFAULT 'active',
+  public_key TEXT NOT NULL,
+  private_key TEXT NOT NULL,
+  expires_at TIMESTAMPTZ NULL,
+  rotated_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT idx_signing_keys_kid UNIQUE (kid),
+  CONSTRAINT chk_signing_keys_status CHECK (status IN ('active', 'rotated', 'revoked')),
+  CONSTRAINT chk_signing_keys_use CHECK (use_ IN ('sig', 'enc'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_signing_keys_status ON signing_keys (status);

--- a/internal/domain/signing_key.go
+++ b/internal/domain/signing_key.go
@@ -1,0 +1,46 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SigningKeyStatus represents the lifecycle position of a JWT signing key.
+//
+//   - active:  newly issued tokens are signed with this key
+//   - rotated: still published in JWKS so tokens issued before rotation remain
+//     verifiable, but new tokens are signed with the active key
+//   - revoked: removed from JWKS; verifications fail
+type SigningKeyStatus string
+
+const (
+	SigningKeyStatusActive  SigningKeyStatus = "active"
+	SigningKeyStatusRotated SigningKeyStatus = "rotated"
+	SigningKeyStatusRevoked SigningKeyStatus = "revoked"
+)
+
+// SigningKeyUse mirrors RFC 7517 §4.2 ("use" parameter).
+type SigningKeyUse string
+
+const (
+	SigningKeyUseSig SigningKeyUse = "sig"
+	SigningKeyUseEnc SigningKeyUse = "enc"
+)
+
+// SigningKey is the persistent form of a JWT signing key. PrivateKeyPEM and
+// PublicKeyPEM hold PEM-encoded RSA material; rotation is driven by Status
+// transitions (active → rotated → revoked) rather than deletion so already-
+// issued tokens keep verifying.
+type SigningKey struct {
+	ID            uuid.UUID
+	KID           string
+	Algorithm     string // RS256, ES256, ...
+	Use           SigningKeyUse
+	Status        SigningKeyStatus
+	PublicKeyPEM  string
+	PrivateKeyPEM string
+	ExpiresAt     *time.Time
+	RotatedAt     *time.Time
+	CreatedAt     time.Time
+}

--- a/internal/keymanager/manager.go
+++ b/internal/keymanager/manager.go
@@ -1,0 +1,235 @@
+// Package keymanager owns the lifecycle of JWT signing keys.
+//
+// The DB-backed signing_keys table is the source of truth (see
+// traPortal v2 spec §signing_keys). On startup the manager ensures at least
+// one ACTIVE key exists, generating one if the table is empty. Token issuance
+// uses ActiveKey(); JWKS exposes every PublishableKey so previously-issued
+// tokens remain verifiable across rotations.
+package keymanager
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository"
+)
+
+const (
+	defaultAlgorithm = "RS256"
+	rsaKeyBits       = 2048
+)
+
+// PublicKeyView is a serialisation-friendly snapshot for JWKS rendering.
+// Holding the parsed public key avoids re-decoding the PEM on every request.
+type PublicKeyView struct {
+	KID       string
+	Algorithm string
+	Use       domain.SigningKeyUse
+	PublicKey *rsa.PublicKey
+}
+
+// Manager wraps a SigningKeyRepository to provide the policy layer
+// ("which key signs?", "which keys verify?") on top of pure storage.
+type Manager struct {
+	repo repository.SigningKeyRepository
+
+	mu        sync.RWMutex
+	activeKey *signedKey
+}
+
+type signedKey struct {
+	id         uuid.UUID
+	kid        string
+	algorithm  string
+	privateKey *rsa.PrivateKey
+}
+
+func New(repo repository.SigningKeyRepository) *Manager {
+	return &Manager{repo: repo}
+}
+
+// EnsureActiveKey loads the current active key from storage and parses it. If
+// no active key exists, a fresh RSA-2048 / RS256 key is generated and
+// persisted with status=active. Idempotent across restarts.
+func (m *Manager) EnsureActiveKey(ctx context.Context) error {
+	key, err := m.repo.GetActive(ctx)
+	if err != nil && !errors.Is(err, repository.ErrSigningKeyNotFound) {
+		return fmt.Errorf("load active signing key: %w", err)
+	}
+	if errors.Is(err, repository.ErrSigningKeyNotFound) {
+		key, err = generateAndPersist(ctx, m.repo)
+		if err != nil {
+			return err
+		}
+	}
+
+	priv, err := decodePrivateKey(key.PrivateKeyPEM)
+	if err != nil {
+		return fmt.Errorf("decode active signing key: %w", err)
+	}
+
+	m.mu.Lock()
+	m.activeKey = &signedKey{
+		id:         key.ID,
+		kid:        key.KID,
+		algorithm:  key.Algorithm,
+		privateKey: priv,
+	}
+	m.mu.Unlock()
+	return nil
+}
+
+// ActiveKey returns the parsed private key currently used to sign new tokens.
+func (m *Manager) ActiveKey() (*rsa.PrivateKey, string, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if m.activeKey == nil {
+		return nil, "", errors.New("no active signing key")
+	}
+	return m.activeKey.privateKey, m.activeKey.kid, nil
+}
+
+// PublishableKeys returns every key that should appear in JWKS (active +
+// rotated). The result is freshly read from storage so admin rotations show
+// up without process restart.
+func (m *Manager) PublishableKeys(ctx context.Context) ([]PublicKeyView, error) {
+	keys, err := m.repo.ListPublishable(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]PublicKeyView, 0, len(keys))
+	for _, k := range keys {
+		pub, err := decodePublicKey(k.PublicKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("decode public key %s: %w", k.KID, err)
+		}
+		out = append(out, PublicKeyView{
+			KID:       k.KID,
+			Algorithm: k.Algorithm,
+			Use:       k.Use,
+			PublicKey: pub,
+		})
+	}
+	return out, nil
+}
+
+// Rotate marks the current active key as rotated and provisions a new one.
+// Old tokens stay verifiable until their natural expiry; new tokens use the
+// fresh key.
+func (m *Manager) Rotate(ctx context.Context) error {
+	current, err := m.repo.GetActive(ctx)
+	if err == nil {
+		if err := m.repo.MarkRotated(ctx, current.ID); err != nil {
+			return fmt.Errorf("mark current key rotated: %w", err)
+		}
+	} else if !errors.Is(err, repository.ErrSigningKeyNotFound) {
+		return err
+	}
+	if _, err := generateAndPersist(ctx, m.repo); err != nil {
+		return err
+	}
+	return m.EnsureActiveKey(ctx)
+}
+
+func generateAndPersist(ctx context.Context, repo repository.SigningKeyRepository) (domain.SigningKey, error) {
+	priv, err := rsa.GenerateKey(rand.Reader, rsaKeyBits)
+	if err != nil {
+		return domain.SigningKey{}, fmt.Errorf("generate RSA key: %w", err)
+	}
+	kid := computeKID(&priv.PublicKey)
+	pubPEM, err := encodePublicKey(&priv.PublicKey)
+	if err != nil {
+		return domain.SigningKey{}, err
+	}
+	privPEM := encodePrivateKey(priv)
+
+	key := domain.SigningKey{
+		ID:            uuid.New(),
+		KID:           kid,
+		Algorithm:     defaultAlgorithm,
+		Use:           domain.SigningKeyUseSig,
+		Status:        domain.SigningKeyStatusActive,
+		PublicKeyPEM:  pubPEM,
+		PrivateKeyPEM: privPEM,
+	}
+	if err := repo.Create(ctx, key); err != nil {
+		return domain.SigningKey{}, fmt.Errorf("persist signing key: %w", err)
+	}
+	return key, nil
+}
+
+// computeKID is a deterministic key-id derived from the RSA modulus. Same
+// scheme the previous PEM-only handler used, so JWKS clients keep observing
+// the same kid for the same key material.
+func computeKID(pub *rsa.PublicKey) string {
+	hash := sha256.Sum256(pub.N.Bytes())
+	return base64.RawURLEncoding.EncodeToString(hash[:8])
+}
+
+func encodePrivateKey(priv *rsa.PrivateKey) string {
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}))
+}
+
+func encodePublicKey(pub *rsa.PublicKey) (string, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", fmt.Errorf("marshal public key: %w", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: der,
+	})), nil
+}
+
+func decodePrivateKey(p string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(p))
+	if block == nil {
+		return nil, errors.New("invalid private key PEM")
+	}
+	switch block.Type {
+	case "RSA PRIVATE KEY":
+		return x509.ParsePKCS1PrivateKey(block.Bytes)
+	case "PRIVATE KEY":
+		parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, err
+		}
+		key, ok := parsed.(*rsa.PrivateKey)
+		if !ok {
+			return nil, errors.New("private key is not RSA")
+		}
+		return key, nil
+	default:
+		return nil, fmt.Errorf("unsupported PEM type: %s", block.Type)
+	}
+}
+
+func decodePublicKey(p string) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode([]byte(p))
+	if block == nil {
+		return nil, errors.New("invalid public key PEM")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+	pub, ok := parsed.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("public key is not RSA")
+	}
+	return pub, nil
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -33,6 +33,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.createOIDCSessionStmt, err = db.PrepareContext(ctx, createOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateOIDCSession: %w", err)
 	}
+	if q.createSigningKeyStmt, err = db.PrepareContext(ctx, createSigningKey); err != nil {
+		return nil, fmt.Errorf("error preparing query CreateSigningKey: %w", err)
+	}
 	if q.createTokenStmt, err = db.PrepareContext(ctx, createToken); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateToken: %w", err)
 	}
@@ -78,6 +81,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteTokensByUserAndClientStmt, err = db.PrepareContext(ctx, deleteTokensByUserAndClient); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteTokensByUserAndClient: %w", err)
 	}
+	if q.getActiveSigningKeyStmt, err = db.PrepareContext(ctx, getActiveSigningKey); err != nil {
+		return nil, fmt.Errorf("error preparing query GetActiveSigningKey: %w", err)
+	}
 	if q.getAuthorizationCodeStmt, err = db.PrepareContext(ctx, getAuthorizationCode); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAuthorizationCode: %w", err)
 	}
@@ -86,6 +92,12 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getOIDCSessionStmt, err = db.PrepareContext(ctx, getOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query GetOIDCSession: %w", err)
+	}
+	if q.getSigningKeyStmt, err = db.PrepareContext(ctx, getSigningKey); err != nil {
+		return nil, fmt.Errorf("error preparing query GetSigningKey: %w", err)
+	}
+	if q.getSigningKeyByKIDStmt, err = db.PrepareContext(ctx, getSigningKeyByKID); err != nil {
+		return nil, fmt.Errorf("error preparing query GetSigningKeyByKID: %w", err)
 	}
 	if q.getTokenByAccessTokenStmt, err = db.PrepareContext(ctx, getTokenByAccessToken); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTokenByAccessToken: %w", err)
@@ -99,8 +111,17 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.listClientsStmt, err = db.PrepareContext(ctx, listClients); err != nil {
 		return nil, fmt.Errorf("error preparing query ListClients: %w", err)
 	}
+	if q.listPublishableSigningKeysStmt, err = db.PrepareContext(ctx, listPublishableSigningKeys); err != nil {
+		return nil, fmt.Errorf("error preparing query ListPublishableSigningKeys: %w", err)
+	}
 	if q.markAuthorizationCodeUsedStmt, err = db.PrepareContext(ctx, markAuthorizationCodeUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkAuthorizationCodeUsed: %w", err)
+	}
+	if q.markSigningKeyRotatedStmt, err = db.PrepareContext(ctx, markSigningKeyRotated); err != nil {
+		return nil, fmt.Errorf("error preparing query MarkSigningKeyRotated: %w", err)
+	}
+	if q.revokeSigningKeyStmt, err = db.PrepareContext(ctx, revokeSigningKey); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeSigningKey: %w", err)
 	}
 	if q.updateAuthorizationCodePKCEStmt, err = db.PrepareContext(ctx, updateAuthorizationCodePKCE); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAuthorizationCodePKCE: %w", err)
@@ -129,6 +150,11 @@ func (q *Queries) Close() error {
 	if q.createOIDCSessionStmt != nil {
 		if cerr := q.createOIDCSessionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createOIDCSessionStmt: %w", cerr)
+		}
+	}
+	if q.createSigningKeyStmt != nil {
+		if cerr := q.createSigningKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing createSigningKeyStmt: %w", cerr)
 		}
 	}
 	if q.createTokenStmt != nil {
@@ -206,6 +232,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing deleteTokensByUserAndClientStmt: %w", cerr)
 		}
 	}
+	if q.getActiveSigningKeyStmt != nil {
+		if cerr := q.getActiveSigningKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getActiveSigningKeyStmt: %w", cerr)
+		}
+	}
 	if q.getAuthorizationCodeStmt != nil {
 		if cerr := q.getAuthorizationCodeStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAuthorizationCodeStmt: %w", cerr)
@@ -219,6 +250,16 @@ func (q *Queries) Close() error {
 	if q.getOIDCSessionStmt != nil {
 		if cerr := q.getOIDCSessionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getOIDCSessionStmt: %w", cerr)
+		}
+	}
+	if q.getSigningKeyStmt != nil {
+		if cerr := q.getSigningKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getSigningKeyStmt: %w", cerr)
+		}
+	}
+	if q.getSigningKeyByKIDStmt != nil {
+		if cerr := q.getSigningKeyByKIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getSigningKeyByKIDStmt: %w", cerr)
 		}
 	}
 	if q.getTokenByAccessTokenStmt != nil {
@@ -241,9 +282,24 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing listClientsStmt: %w", cerr)
 		}
 	}
+	if q.listPublishableSigningKeysStmt != nil {
+		if cerr := q.listPublishableSigningKeysStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listPublishableSigningKeysStmt: %w", cerr)
+		}
+	}
 	if q.markAuthorizationCodeUsedStmt != nil {
 		if cerr := q.markAuthorizationCodeUsedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markAuthorizationCodeUsedStmt: %w", cerr)
+		}
+	}
+	if q.markSigningKeyRotatedStmt != nil {
+		if cerr := q.markSigningKeyRotatedStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing markSigningKeyRotatedStmt: %w", cerr)
+		}
+	}
+	if q.revokeSigningKeyStmt != nil {
+		if cerr := q.revokeSigningKeyStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeSigningKeyStmt: %w", cerr)
 		}
 	}
 	if q.updateAuthorizationCodePKCEStmt != nil {
@@ -303,6 +359,7 @@ type Queries struct {
 	createAuthorizationCodeStmt         *sql.Stmt
 	createClientStmt                    *sql.Stmt
 	createOIDCSessionStmt               *sql.Stmt
+	createSigningKeyStmt                *sql.Stmt
 	createTokenStmt                     *sql.Stmt
 	deleteAllAuthorizationCodesStmt     *sql.Stmt
 	deleteAllClientsStmt                *sql.Stmt
@@ -318,14 +375,20 @@ type Queries struct {
 	deleteTokenByRefreshTokenStmt       *sql.Stmt
 	deleteTokensByRequestIDStmt         *sql.Stmt
 	deleteTokensByUserAndClientStmt     *sql.Stmt
+	getActiveSigningKeyStmt             *sql.Stmt
 	getAuthorizationCodeStmt            *sql.Stmt
 	getClientStmt                       *sql.Stmt
 	getOIDCSessionStmt                  *sql.Stmt
+	getSigningKeyStmt                   *sql.Stmt
+	getSigningKeyByKIDStmt              *sql.Stmt
 	getTokenByAccessTokenStmt           *sql.Stmt
 	getTokenByIDStmt                    *sql.Stmt
 	getTokenByRefreshTokenStmt          *sql.Stmt
 	listClientsStmt                     *sql.Stmt
+	listPublishableSigningKeysStmt      *sql.Stmt
 	markAuthorizationCodeUsedStmt       *sql.Stmt
+	markSigningKeyRotatedStmt           *sql.Stmt
+	revokeSigningKeyStmt                *sql.Stmt
 	updateAuthorizationCodePKCEStmt     *sql.Stmt
 	updateClientStmt                    *sql.Stmt
 	updateClientSecretStmt              *sql.Stmt
@@ -338,6 +401,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createAuthorizationCodeStmt:         q.createAuthorizationCodeStmt,
 		createClientStmt:                    q.createClientStmt,
 		createOIDCSessionStmt:               q.createOIDCSessionStmt,
+		createSigningKeyStmt:                q.createSigningKeyStmt,
 		createTokenStmt:                     q.createTokenStmt,
 		deleteAllAuthorizationCodesStmt:     q.deleteAllAuthorizationCodesStmt,
 		deleteAllClientsStmt:                q.deleteAllClientsStmt,
@@ -353,14 +417,20 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteTokenByRefreshTokenStmt:       q.deleteTokenByRefreshTokenStmt,
 		deleteTokensByRequestIDStmt:         q.deleteTokensByRequestIDStmt,
 		deleteTokensByUserAndClientStmt:     q.deleteTokensByUserAndClientStmt,
+		getActiveSigningKeyStmt:             q.getActiveSigningKeyStmt,
 		getAuthorizationCodeStmt:            q.getAuthorizationCodeStmt,
 		getClientStmt:                       q.getClientStmt,
 		getOIDCSessionStmt:                  q.getOIDCSessionStmt,
+		getSigningKeyStmt:                   q.getSigningKeyStmt,
+		getSigningKeyByKIDStmt:              q.getSigningKeyByKIDStmt,
 		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
 		getTokenByIDStmt:                    q.getTokenByIDStmt,
 		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
 		listClientsStmt:                     q.listClientsStmt,
+		listPublishableSigningKeysStmt:      q.listPublishableSigningKeysStmt,
 		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
+		markSigningKeyRotatedStmt:           q.markSigningKeyRotatedStmt,
+		revokeSigningKeyStmt:                q.revokeSigningKeyStmt,
 		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,
 		updateClientStmt:                    q.updateClientStmt,
 		updateClientSecretStmt:              q.updateClientSecretStmt,

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -47,6 +47,19 @@ type OidcSession struct {
 	CreatedAt     time.Time      `json:"created_at"`
 }
 
+type SigningKey struct {
+	ID         uuid.UUID    `json:"id"`
+	Kid        string       `json:"kid"`
+	Algorithm  string       `json:"algorithm"`
+	Use        string       `json:"use_"`
+	Status     string       `json:"status"`
+	PublicKey  string       `json:"public_key"`
+	PrivateKey string       `json:"private_key"`
+	ExpiresAt  sql.NullTime `json:"expires_at"`
+	RotatedAt  sql.NullTime `json:"rotated_at"`
+	CreatedAt  time.Time    `json:"created_at"`
+}
+
 type Token struct {
 	ID           uuid.UUID      `json:"id"`
 	RequestID    string         `json:"request_id"`

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -125,6 +125,46 @@ func (q *Queries) CreateOIDCSession(ctx context.Context, arg CreateOIDCSessionPa
 	return err
 }
 
+const createSigningKey = `-- name: CreateSigningKey :exec
+
+INSERT INTO signing_keys (
+    id,
+    kid,
+    algorithm,
+    use_,
+    status,
+    public_key,
+    private_key,
+    expires_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+`
+
+type CreateSigningKeyParams struct {
+	ID         uuid.UUID    `json:"id"`
+	Kid        string       `json:"kid"`
+	Algorithm  string       `json:"algorithm"`
+	Use        string       `json:"use_"`
+	Status     string       `json:"status"`
+	PublicKey  string       `json:"public_key"`
+	PrivateKey string       `json:"private_key"`
+	ExpiresAt  sql.NullTime `json:"expires_at"`
+}
+
+// Signing key queries
+func (q *Queries) CreateSigningKey(ctx context.Context, arg CreateSigningKeyParams) error {
+	_, err := q.exec(ctx, q.createSigningKeyStmt, createSigningKey,
+		arg.ID,
+		arg.Kid,
+		arg.Algorithm,
+		arg.Use,
+		arg.Status,
+		arg.PublicKey,
+		arg.PrivateKey,
+		arg.ExpiresAt,
+	)
+	return err
+}
+
 const createToken = `-- name: CreateToken :exec
 
 INSERT INTO tokens (
@@ -296,6 +336,31 @@ func (q *Queries) DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTok
 	return err
 }
 
+const getActiveSigningKey = `-- name: GetActiveSigningKey :one
+SELECT id, kid, algorithm, use_, status, public_key, private_key, expires_at, rotated_at, created_at FROM signing_keys
+WHERE status = 'active' AND use_ = 'sig'
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetActiveSigningKey(ctx context.Context) (SigningKey, error) {
+	row := q.queryRow(ctx, q.getActiveSigningKeyStmt, getActiveSigningKey)
+	var i SigningKey
+	err := row.Scan(
+		&i.ID,
+		&i.Kid,
+		&i.Algorithm,
+		&i.Use,
+		&i.Status,
+		&i.PublicKey,
+		&i.PrivateKey,
+		&i.ExpiresAt,
+		&i.RotatedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const getAuthorizationCode = `-- name: GetAuthorizationCode :one
 SELECT code, client_id, user_id, redirect_uri, scopes, code_challenge, code_challenge_method, nonce, used, expires_at, created_at FROM authorization_codes WHERE code = $1
 `
@@ -353,6 +418,50 @@ func (q *Queries) GetOIDCSession(ctx context.Context, authorizeCode string) (Oid
 		&i.Nonce,
 		&i.AuthTime,
 		&i.RequestedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getSigningKey = `-- name: GetSigningKey :one
+SELECT id, kid, algorithm, use_, status, public_key, private_key, expires_at, rotated_at, created_at FROM signing_keys WHERE id = $1
+`
+
+func (q *Queries) GetSigningKey(ctx context.Context, id uuid.UUID) (SigningKey, error) {
+	row := q.queryRow(ctx, q.getSigningKeyStmt, getSigningKey, id)
+	var i SigningKey
+	err := row.Scan(
+		&i.ID,
+		&i.Kid,
+		&i.Algorithm,
+		&i.Use,
+		&i.Status,
+		&i.PublicKey,
+		&i.PrivateKey,
+		&i.ExpiresAt,
+		&i.RotatedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getSigningKeyByKID = `-- name: GetSigningKeyByKID :one
+SELECT id, kid, algorithm, use_, status, public_key, private_key, expires_at, rotated_at, created_at FROM signing_keys WHERE kid = $1
+`
+
+func (q *Queries) GetSigningKeyByKID(ctx context.Context, kid string) (SigningKey, error) {
+	row := q.queryRow(ctx, q.getSigningKeyByKIDStmt, getSigningKeyByKID, kid)
+	var i SigningKey
+	err := row.Scan(
+		&i.ID,
+		&i.Kid,
+		&i.Algorithm,
+		&i.Use,
+		&i.Status,
+		&i.PublicKey,
+		&i.PrivateKey,
+		&i.ExpiresAt,
+		&i.RotatedAt,
 		&i.CreatedAt,
 	)
 	return i, err
@@ -456,12 +565,74 @@ func (q *Queries) ListClients(ctx context.Context) ([]Client, error) {
 	return items, nil
 }
 
+const listPublishableSigningKeys = `-- name: ListPublishableSigningKeys :many
+SELECT id, kid, algorithm, use_, status, public_key, private_key, expires_at, rotated_at, created_at FROM signing_keys
+WHERE status IN ('active', 'rotated')
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListPublishableSigningKeys(ctx context.Context) ([]SigningKey, error) {
+	rows, err := q.query(ctx, q.listPublishableSigningKeysStmt, listPublishableSigningKeys)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []SigningKey{}
+	for rows.Next() {
+		var i SigningKey
+		if err := rows.Scan(
+			&i.ID,
+			&i.Kid,
+			&i.Algorithm,
+			&i.Use,
+			&i.Status,
+			&i.PublicKey,
+			&i.PrivateKey,
+			&i.ExpiresAt,
+			&i.RotatedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markAuthorizationCodeUsed = `-- name: MarkAuthorizationCodeUsed :exec
 UPDATE authorization_codes SET used = TRUE WHERE code = $1
 `
 
 func (q *Queries) MarkAuthorizationCodeUsed(ctx context.Context, code string) error {
 	_, err := q.exec(ctx, q.markAuthorizationCodeUsedStmt, markAuthorizationCodeUsed, code)
+	return err
+}
+
+const markSigningKeyRotated = `-- name: MarkSigningKeyRotated :exec
+UPDATE signing_keys
+SET status = 'rotated', rotated_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND status = 'active'
+`
+
+func (q *Queries) MarkSigningKeyRotated(ctx context.Context, id uuid.UUID) error {
+	_, err := q.exec(ctx, q.markSigningKeyRotatedStmt, markSigningKeyRotated, id)
+	return err
+}
+
+const revokeSigningKey = `-- name: RevokeSigningKey :exec
+UPDATE signing_keys
+SET status = 'revoked'
+WHERE id = $1
+`
+
+func (q *Queries) RevokeSigningKey(ctx context.Context, id uuid.UUID) error {
+	_, err := q.exec(ctx, q.revokeSigningKeyStmt, revokeSigningKey, id)
 	return err
 }
 

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -18,6 +18,8 @@ type Querier interface {
 	CreateClient(ctx context.Context, arg CreateClientParams) error
 	// OIDC Session queries
 	CreateOIDCSession(ctx context.Context, arg CreateOIDCSessionParams) error
+	// Signing key queries
+	CreateSigningKey(ctx context.Context, arg CreateSigningKeyParams) error
 	// Token queries
 	CreateToken(ctx context.Context, arg CreateTokenParams) error
 	DeleteAllAuthorizationCodes(ctx context.Context) error
@@ -34,14 +36,20 @@ type Querier interface {
 	DeleteTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) error
 	DeleteTokensByRequestID(ctx context.Context, requestID string) error
 	DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTokensByUserAndClientParams) error
+	GetActiveSigningKey(ctx context.Context) (SigningKey, error)
 	GetAuthorizationCode(ctx context.Context, code string) (AuthorizationCode, error)
 	GetClient(ctx context.Context, clientID uuid.UUID) (Client, error)
 	GetOIDCSession(ctx context.Context, authorizeCode string) (OidcSession, error)
+	GetSigningKey(ctx context.Context, id uuid.UUID) (SigningKey, error)
+	GetSigningKeyByKID(ctx context.Context, kid string) (SigningKey, error)
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
 	ListClients(ctx context.Context) ([]Client, error)
+	ListPublishableSigningKeys(ctx context.Context) ([]SigningKey, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
+	MarkSigningKeyRotated(ctx context.Context, id uuid.UUID) error
+	RevokeSigningKey(ctx context.Context, id uuid.UUID) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error
 	UpdateClient(ctx context.Context, arg UpdateClientParams) error
 	UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error

--- a/internal/repository/signing_key.go
+++ b/internal/repository/signing_key.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+var ErrSigningKeyNotFound = errors.New("signing key not found")
+
+type SigningKeyRepository interface {
+	Create(ctx context.Context, key domain.SigningKey) error
+	GetByKID(ctx context.Context, kid string) (domain.SigningKey, error)
+	GetActive(ctx context.Context) (domain.SigningKey, error)
+	ListPublishable(ctx context.Context) ([]domain.SigningKey, error)
+	MarkRotated(ctx context.Context, id uuid.UUID) error
+	Revoke(ctx context.Context, id uuid.UUID) error
+}
+
+type signingKeyRepository struct {
+	queries *oidc.Queries
+}
+
+func NewSigningKeyRepository(queries *oidc.Queries) SigningKeyRepository {
+	return &signingKeyRepository{queries: queries}
+}
+
+func (r *signingKeyRepository) Create(ctx context.Context, key domain.SigningKey) error {
+	expiresAt := sql.NullTime{}
+	if key.ExpiresAt != nil {
+		expiresAt = sql.NullTime{Time: *key.ExpiresAt, Valid: true}
+	}
+	return r.queries.CreateSigningKey(ctx, oidc.CreateSigningKeyParams{
+		ID:         key.ID,
+		Kid:        key.KID,
+		Algorithm:  key.Algorithm,
+		Use:        string(key.Use),
+		Status:     string(key.Status),
+		PublicKey:  key.PublicKeyPEM,
+		PrivateKey: key.PrivateKeyPEM,
+		ExpiresAt:  expiresAt,
+	})
+}
+
+func (r *signingKeyRepository) GetByKID(ctx context.Context, kid string) (domain.SigningKey, error) {
+	row, err := r.queries.GetSigningKeyByKID(ctx, kid)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SigningKey{}, ErrSigningKeyNotFound
+		}
+		return domain.SigningKey{}, err
+	}
+	return toDomainSigningKey(row), nil
+}
+
+func (r *signingKeyRepository) GetActive(ctx context.Context) (domain.SigningKey, error) {
+	row, err := r.queries.GetActiveSigningKey(ctx)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.SigningKey{}, ErrSigningKeyNotFound
+		}
+		return domain.SigningKey{}, err
+	}
+	return toDomainSigningKey(row), nil
+}
+
+func (r *signingKeyRepository) ListPublishable(ctx context.Context) ([]domain.SigningKey, error) {
+	rows, err := r.queries.ListPublishableSigningKeys(ctx)
+	if err != nil {
+		return nil, err
+	}
+	keys := make([]domain.SigningKey, 0, len(rows))
+	for _, row := range rows {
+		keys = append(keys, toDomainSigningKey(row))
+	}
+	return keys, nil
+}
+
+func (r *signingKeyRepository) MarkRotated(ctx context.Context, id uuid.UUID) error {
+	return r.queries.MarkSigningKeyRotated(ctx, id)
+}
+
+func (r *signingKeyRepository) Revoke(ctx context.Context, id uuid.UUID) error {
+	return r.queries.RevokeSigningKey(ctx, id)
+}
+
+func toDomainSigningKey(row oidc.SigningKey) domain.SigningKey {
+	var expiresAt *time.Time
+	if row.ExpiresAt.Valid {
+		t := row.ExpiresAt.Time
+		expiresAt = &t
+	}
+	var rotatedAt *time.Time
+	if row.RotatedAt.Valid {
+		t := row.RotatedAt.Time
+		rotatedAt = &t
+	}
+	return domain.SigningKey{
+		ID:            row.ID,
+		KID:           row.Kid,
+		Algorithm:     row.Algorithm,
+		Use:           domain.SigningKeyUse(row.Use),
+		Status:        domain.SigningKeyStatus(row.Status),
+		PublicKeyPEM:  row.PublicKey,
+		PrivateKeyPEM: row.PrivateKey,
+		ExpiresAt:     expiresAt,
+		RotatedAt:     rotatedAt,
+		CreatedAt:     row.CreatedAt,
+	}
+}

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 
+	"github.com/traPtitech/portal-oidc/internal/keymanager"
 	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
@@ -179,7 +180,12 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
+	keys := keymanager.New(repository.NewSigningKeyRepository(queries))
+	if err := keys.EnsureActiveKey(ctx); err != nil {
+		t.Fatalf("failed to ensure active signing key: %v", err)
+	}
+
+	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, keys, OAuthConfig{
 		Issuer:      "http://localhost:8080",
 		Environment: "development",
 		TestUserID:  "00000000-0000-0000-0000-000000000000",

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"crypto/rsa"
 	"net/http"
 	"strings"
@@ -8,8 +9,17 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/keymanager"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
+
+// KeyProvider abstracts the JWT signing key store so the router does not
+// depend on its concrete implementation. Tests can supply an in-memory fake
+// without dragging in the keymanager package.
+type KeyProvider interface {
+	ActiveKey() (*rsa.PrivateKey, string, error)
+	PublishableKeys(ctx context.Context) ([]keymanager.PublicKeyView, error)
+}
 
 type Handler struct {
 	clientUseCase usecase.ClientUseCase
@@ -17,13 +27,13 @@ type Handler struct {
 	oauth2        fosite.OAuth2Provider
 	userUseCase   usecase.UserUseCase
 	sessions      *sessions.CookieStore
+	keys          KeyProvider
 	config        OAuthConfig
 }
 
 type OAuthConfig struct {
 	Issuer        string
 	SessionSecret []byte // #nosec G117 -- internal config, not serialized
-	PrivateKey    *rsa.PrivateKey
 	Environment   string
 	TestUserID    string
 }
@@ -33,6 +43,7 @@ func NewHandler(
 	oauthUseCase usecase.OAuthUseCase,
 	oauth2 fosite.OAuth2Provider,
 	userUseCase usecase.UserUseCase,
+	keys KeyProvider,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -50,6 +61,7 @@ func NewHandler(
 		oauth2:        oauth2,
 		userUseCase:   userUseCase,
 		sessions:      store,
+		keys:          keys,
 		config:        config,
 	}
 }

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -1,8 +1,6 @@
 package v1
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
 	"net/http"
 	"net/url"
@@ -242,24 +240,35 @@ func (h *Handler) handleUserInfo(ctx *echo.Context, token string) error {
 	return ctx.JSON(http.StatusOK, info)
 }
 
+// GetJWKS publishes every active and rotated signing key so RPs can verify
+// tokens issued before the most recent rotation. Revoked keys are excluded.
+//
+// Refs:
+//   - RFC 7517 §5 (JWK Set Format)
+//     https://datatracker.ietf.org/doc/html/rfc7517#section-5
+//   - OIDC Discovery 1.0 §10.1 (Key Rotation)
+//     https://openid.net/specs/openid-connect-discovery-1_0.html#RotateSigKeys
 func (h *Handler) GetJWKS(ctx *echo.Context) error {
-	if h.config.PrivateKey == nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, "signing key not configured")
+	keys, err := h.keys.PublishableKeys(ctx.Request().Context())
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to load signing keys")
 	}
-	pubKey := &h.config.PrivateKey.PublicKey
+	if len(keys) == 0 {
+		return echo.NewHTTPError(http.StatusInternalServerError, "no signing keys available")
+	}
 
-	hash := sha256.Sum256(pubKey.N.Bytes())
-	kid := base64.RawURLEncoding.EncodeToString(hash[:8])
-
-	jwk := jose.JSONWebKey{
-		Key:       pubKey,
-		KeyID:     kid,
-		Algorithm: string(jose.RS256),
-		Use:       "sig",
+	jwks := make([]jose.JSONWebKey, 0, len(keys))
+	for _, k := range keys {
+		jwks = append(jwks, jose.JSONWebKey{
+			Key:       k.PublicKey,
+			KeyID:     k.KID,
+			Algorithm: k.Algorithm,
+			Use:       string(k.Use),
+		})
 	}
 
 	return ctx.JSON(http.StatusOK, map[string]interface{}{
-		"keys": []jose.JSONWebKey{jwk},
+		"keys": jwks,
 	})
 }
 


### PR DESCRIPTION
## 概要

JWT 署名鍵を PEM ファイル (\`data/private.pem\`) から spec 準拠の \`signing_keys\` テーブルへ移行。複数鍵共存と JWKS でのローテーション公開を可能にする。

## 背景

仕様の \`signing_keys\` テーブル定義に対応:
| カラム | 型 | 説明 |
|---|---|---|
| id | UUID | PK |
| kid | TEXT | UNIQUE, JWK Key ID |
| algorithm | TEXT | RS256 / ES256 |
| use_ | TEXT | sig / enc (\`use\` は予約語) |
| status | TEXT | active / rotated / revoked |
| public_key | TEXT | PEM |
| private_key | TEXT | PEM |
| expires_at, rotated_at, created_at | TIMESTAMPTZ | |

ローテーション時は \`active → rotated\` で JWKS に残し続け、過去発行トークンが検証可能なまま新トークンは新 active 鍵で署名。

## 変更

### スキーマ・クエリ
- \`db/schema.sql\`: \`signing_keys\` テーブル追加 (status / use の CHECK 制約付き)
- \`db/query/oidc.sql\`: CRUD + \`GetActiveSigningKey\`, \`ListPublishableSigningKeys\`, \`MarkSigningKeyRotated\`, \`RevokeSigningKey\`
- \`internal/repository/oidc/*\`: sqlc 自動生成

### Domain / Repository
- \`internal/domain/signing_key.go\`: \`SigningKey\` 構造体 + status / use enum
- \`internal/repository/signing_key.go\`: \`SigningKeyRepository\` 実装

### keymanager パッケージ (新規)
- \`internal/keymanager/manager.go\`:
  - \`EnsureActiveKey\`: 起動時に active 鍵が無ければ自動生成
  - \`ActiveKey\`: fosite signer 用の現役 private key
  - \`PublishableKeys\`: JWKS 公開用 (active + rotated)
  - \`Rotate\`: 既存を rotated に降格して新鍵を active 化

### Wiring
- \`cmd/serve.go\`: keymanager を構築・初期化、fosite と handler に注入
- \`cmd/oauth.go\`: \`privateKeyGetter\` を keymanager 経由に変更。PEM ファイル系のヘルパー (\`loadOrGenerateKey\` / \`loadKey\` / \`saveKey\`) と未使用の import を削除
- \`cmd/config.go\`: 未使用の \`oauth.key_file\` を削除
- \`internal/router/v1/handler.go\`: \`OAuthConfig.PrivateKey\` を削除し、\`KeyProvider\` interface 経由で keymanager を受け取る
- \`internal/router/v1/oauth.go\`: \`GetJWKS\` で publishable keys 全件を返却 (回転後も RP は古いトークンを検証可能)
- \`internal/router/v1/client_test.go\`: keymanager で active 鍵をプロビジョン
- \`.github/workflows/conformance.yaml\`: 不要になった \`openssl genpkey\` ステップを削除

### 互換性
- 既存の kid 計算 (sha256(modulus) の base64url 先頭 8 byte) を踏襲
- 既存 PEM ファイルは無視される (DB 側で別 kid を生成)

## RFC / 仕様根拠

| 項目 | 仕様 |
|---|---|
| signing_keys テーブル | traPortal v2 仕様 |
| JWK / JWK Set フォーマット | [RFC 7517 §4](https://datatracker.ietf.org/doc/html/rfc7517#section-4), [§5](https://datatracker.ietf.org/doc/html/rfc7517#section-5) |
| Key Rotation 公開 | [OIDC Discovery 1.0 §10.1](https://openid.net/specs/openid-connect-discovery-1_0.html#RotateSigKeys) |

## 後続 PR
- 管理者 API \`/api/v1/admin/keys/rotate\` で手動回転
- PR #134 (RP-Initiated Logout) を \`KeyProvider.PublishableKeys\` で全鍵照合に変更
- ID Token に \`kid\` ヘッダーを明示 (現状は単一 active 鍵なので暗黙)

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)