### PR TITLE
feat(audit): audit_logs テーブル追加 + login/token イベント記録

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/labstack/echo/v5/middleware"
 
+	"github.com/traPtitech/portal-oidc/internal/audit"
 	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
@@ -60,11 +61,13 @@ func newServer(cfg Config) (http.Handler, error) {
 		}
 		userUseCase = usecase.NewUserUseCase(repository.NewUserRepository(portalQueries))
 	}
+	auditLogger := audit.NewLogger(repository.NewAuditLogRepository(queries))
 	handler := v1.NewHandler(
 		usecase.NewClientUseCase(clientRepo),
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
 		userUseCase,
+		auditLogger,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,35 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- Audit log queries
+
+-- name: CreateAuditLog :exec
+INSERT INTO audit_logs (
+    id,
+    event_type,
+    user_id,
+    client_id,
+    session_id,
+    ip_address,
+    user_agent,
+    details
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+
+-- name: ListAuditLogsByUser :many
+SELECT * FROM audit_logs
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3;
+
+-- name: ListAuditLogsByClient :many
+SELECT * FROM audit_logs
+WHERE client_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3;
+
+-- name: ListAuditLogsByEventType :many
+SELECT * FROM audit_logs
+WHERE event_type = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,27 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §audit_logs
+-- Append-only event log for security-sensitive actions. user_id / client_id
+-- are nullable because not every event type has a subject (e.g. an
+-- unauthenticated token introspection still gets logged for forensics).
+-- details holds free-form JSON so new event types do not require schema
+-- changes.
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id UUID NOT NULL,
+  event_type TEXT NOT NULL,
+  user_id UUID NULL,
+  client_id UUID NULL,
+  session_id TEXT NULL,
+  ip_address TEXT NULL,
+  user_agent TEXT NULL,
+  details JSONB NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_event_type ON audit_logs (event_type);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_user_id ON audit_logs (user_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_client_id ON audit_logs (client_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_created_at ON audit_logs (created_at);

--- a/internal/audit/logger.go
+++ b/internal/audit/logger.go
@@ -1,0 +1,120 @@
+// Package audit captures security-sensitive events to the audit_logs table.
+//
+// Audit logging is best-effort by design: a failure to persist an event is
+// logged via the standard log package but never propagated to the caller,
+// because dropping a real request because of a logging failure would create
+// a broader security problem than missing an audit row.
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"net"
+	"net/http"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository"
+)
+
+// Logger persists audit events through a repository.
+type Logger struct {
+	repo repository.AuditLogRepository
+}
+
+func NewLogger(repo repository.AuditLogRepository) *Logger {
+	return &Logger{repo: repo}
+}
+
+// Event is the minimal payload callers fill in. Convenience constructors
+// (LoginSuccess, TokenIssued, ...) mostly translate handler-side data into
+// this shape.
+type Event struct {
+	Type      domain.AuditEventType
+	UserID    *uuid.UUID
+	ClientID  *uuid.UUID
+	SessionID string
+	IPAddress string
+	UserAgent string
+	Details   map[string]any
+}
+
+// Record persists one event. Best-effort: errors are logged and swallowed.
+func (l *Logger) Record(ctx context.Context, ev Event) {
+	if l == nil {
+		return
+	}
+	var details []byte
+	if len(ev.Details) > 0 {
+		raw, err := json.Marshal(ev.Details)
+		if err != nil {
+			log.Printf("audit: marshal details for %s: %v", ev.Type, err)
+		} else {
+			details = raw
+		}
+	}
+	row := domain.AuditLog{
+		ID:        uuid.New(),
+		EventType: ev.Type,
+		UserID:    ev.UserID,
+		ClientID:  ev.ClientID,
+		SessionID: ev.SessionID,
+		IPAddress: ev.IPAddress,
+		UserAgent: ev.UserAgent,
+		Details:   details,
+	}
+	if err := l.repo.Create(ctx, row); err != nil {
+		log.Printf("audit: persist %s: %v", ev.Type, err)
+	}
+}
+
+// FromRequest extracts the IP address (honouring X-Forwarded-For when
+// trusted) and User-Agent from the inbound request. The X-Forwarded-For
+// handling is deliberately permissive because traPortal sits behind a single
+// trusted reverse proxy in production; tighten if that assumption changes.
+func FromRequest(r *http.Request) (ip, ua string) {
+	if r == nil {
+		return "", ""
+	}
+	if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+		// First entry is the original client per RFC 7239 / common proxy
+		// convention.
+		if comma := indexComma(forwarded); comma >= 0 {
+			ip = trimSpace(forwarded[:comma])
+		} else {
+			ip = trimSpace(forwarded)
+		}
+	}
+	if ip == "" {
+		host, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			ip = r.RemoteAddr
+		} else {
+			ip = host
+		}
+	}
+	ua = r.Header.Get("User-Agent")
+	return ip, ua
+}
+
+func indexComma(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == ',' {
+			return i
+		}
+	}
+	return -1
+}
+
+func trimSpace(s string) string {
+	start, end := 0, len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/domain/audit.go
+++ b/internal/domain/audit.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// AuditEventType is a stable string identifier for security-relevant events.
+// New types may be added freely; consumers should treat unknown values as
+// generic events.
+type AuditEventType string
+
+const (
+	AuditEventLoginSuccess     AuditEventType = "auth.login.success"
+	AuditEventLoginFailure     AuditEventType = "auth.login.failure"
+	AuditEventLogout           AuditEventType = "auth.logout"
+	AuditEventTokenIssued      AuditEventType = "token.issued"
+	AuditEventTokenRevoked     AuditEventType = "token.revoked"
+	AuditEventTokenIntrospect  AuditEventType = "token.introspected"
+	AuditEventClientCreated    AuditEventType = "client.created"
+	AuditEventClientUpdated    AuditEventType = "client.updated"
+	AuditEventClientDeleted    AuditEventType = "client.deleted"
+	AuditEventClientSecretGen  AuditEventType = "client.secret_regenerated"
+	AuditEventSigningKeyRotate AuditEventType = "signing_key.rotated"
+)
+
+// AuditLog is one persisted entry in the audit_logs table.
+//
+// UserID and ClientID are optional because not every event has a subject
+// (e.g. an anonymous introspection still gets logged for forensics). Details
+// is free-form JSON so adding new event shapes does not require schema
+// changes.
+type AuditLog struct {
+	ID        uuid.UUID
+	EventType AuditEventType
+	UserID    *uuid.UUID
+	ClientID  *uuid.UUID
+	SessionID string
+	IPAddress string
+	UserAgent string
+	Details   []byte // raw JSON; nil when no details captured
+	CreatedAt time.Time
+}

--- a/internal/repository/audit.go
+++ b/internal/repository/audit.go
@@ -1,0 +1,147 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+type AuditLogQuery struct {
+	UserID    *uuid.UUID
+	ClientID  *uuid.UUID
+	EventType *domain.AuditEventType
+	Limit     int32
+	Offset    int32
+}
+
+type AuditLogRepository interface {
+	Create(ctx context.Context, log domain.AuditLog) error
+	List(ctx context.Context, q AuditLogQuery) ([]domain.AuditLog, error)
+}
+
+type auditLogRepository struct {
+	queries *oidc.Queries
+}
+
+func NewAuditLogRepository(queries *oidc.Queries) AuditLogRepository {
+	return &auditLogRepository{queries: queries}
+}
+
+func (r *auditLogRepository) Create(ctx context.Context, log domain.AuditLog) error {
+	details := pqtype.NullRawMessage{}
+	if len(log.Details) > 0 {
+		details = pqtype.NullRawMessage{RawMessage: log.Details, Valid: true}
+	}
+	return r.queries.CreateAuditLog(ctx, oidc.CreateAuditLogParams{
+		ID:        log.ID,
+		EventType: string(log.EventType),
+		UserID:    nullUUID(log.UserID),
+		ClientID:  nullUUID(log.ClientID),
+		SessionID: nullString(log.SessionID),
+		IpAddress: nullString(log.IPAddress),
+		UserAgent: nullString(log.UserAgent),
+		Details:   details,
+	})
+}
+
+// List dispatches to the most selective sqlc query supported by the filter.
+// Filters are combined as AND; the helper currently supports single-field
+// queries (userID OR clientID OR eventType). Combining filters at the SQL
+// layer is a follow-up.
+func (r *auditLogRepository) List(ctx context.Context, q AuditLogQuery) ([]domain.AuditLog, error) {
+	limit := q.Limit
+	if limit <= 0 {
+		limit = 100
+	}
+	offset := q.Offset
+
+	switch {
+	case q.UserID != nil:
+		rows, err := r.queries.ListAuditLogsByUser(ctx, oidc.ListAuditLogsByUserParams{
+			UserID: nullUUID(q.UserID),
+			Limit:  limit,
+			Offset: offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return mapAuditRows(rows), nil
+	case q.ClientID != nil:
+		rows, err := r.queries.ListAuditLogsByClient(ctx, oidc.ListAuditLogsByClientParams{
+			ClientID: nullUUID(q.ClientID),
+			Limit:    limit,
+			Offset:   offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return mapAuditRows(rows), nil
+	case q.EventType != nil:
+		rows, err := r.queries.ListAuditLogsByEventType(ctx, oidc.ListAuditLogsByEventTypeParams{
+			EventType: string(*q.EventType),
+			Limit:     limit,
+			Offset:    offset,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return mapAuditRows(rows), nil
+	default:
+		return nil, sql.ErrNoRows
+	}
+}
+
+func mapAuditRows(rows []oidc.AuditLog) []domain.AuditLog {
+	out := make([]domain.AuditLog, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toDomainAuditLog(row))
+	}
+	return out
+}
+
+// nullUUID converts an optional uuid.UUID into the sql.NullUUID shape
+// required by the sqlc-generated parameter structs. (A package-level helper
+// will live in repository.go once #135 lands; until then this is duplicated
+// to keep the audit branch independently buildable.)
+func nullUUID(id *uuid.UUID) uuid.NullUUID {
+	if id == nil {
+		return uuid.NullUUID{}
+	}
+	return uuid.NullUUID{UUID: *id, Valid: true}
+}
+
+func nullString(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+func toDomainAuditLog(row oidc.AuditLog) domain.AuditLog {
+	var userID, clientID *uuid.UUID
+	if row.UserID.Valid {
+		id := row.UserID.UUID
+		userID = &id
+	}
+	if row.ClientID.Valid {
+		id := row.ClientID.UUID
+		clientID = &id
+	}
+	var details []byte
+	if row.Details.Valid {
+		details = row.Details.RawMessage
+	}
+	return domain.AuditLog{
+		ID:        row.ID,
+		EventType: domain.AuditEventType(row.EventType),
+		UserID:    userID,
+		ClientID:  clientID,
+		SessionID: row.SessionID.String,
+		IPAddress: row.IpAddress.String,
+		UserAgent: row.UserAgent.String,
+		Details:   details,
+		CreatedAt: row.CreatedAt,
+	}
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -24,6 +24,9 @@ func New(db DBTX) *Queries {
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
+	if q.createAuditLogStmt, err = db.PrepareContext(ctx, createAuditLog); err != nil {
+		return nil, fmt.Errorf("error preparing query CreateAuditLog: %w", err)
+	}
 	if q.createAuthorizationCodeStmt, err = db.PrepareContext(ctx, createAuthorizationCode); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateAuthorizationCode: %w", err)
 	}
@@ -96,6 +99,15 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getTokenByRefreshTokenStmt, err = db.PrepareContext(ctx, getTokenByRefreshToken); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTokenByRefreshToken: %w", err)
 	}
+	if q.listAuditLogsByClientStmt, err = db.PrepareContext(ctx, listAuditLogsByClient); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAuditLogsByClient: %w", err)
+	}
+	if q.listAuditLogsByEventTypeStmt, err = db.PrepareContext(ctx, listAuditLogsByEventType); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAuditLogsByEventType: %w", err)
+	}
+	if q.listAuditLogsByUserStmt, err = db.PrepareContext(ctx, listAuditLogsByUser); err != nil {
+		return nil, fmt.Errorf("error preparing query ListAuditLogsByUser: %w", err)
+	}
 	if q.listClientsStmt, err = db.PrepareContext(ctx, listClients); err != nil {
 		return nil, fmt.Errorf("error preparing query ListClients: %w", err)
 	}
@@ -116,6 +128,11 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 
 func (q *Queries) Close() error {
 	var err error
+	if q.createAuditLogStmt != nil {
+		if cerr := q.createAuditLogStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing createAuditLogStmt: %w", cerr)
+		}
+	}
 	if q.createAuthorizationCodeStmt != nil {
 		if cerr := q.createAuthorizationCodeStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createAuthorizationCodeStmt: %w", cerr)
@@ -236,6 +253,21 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getTokenByRefreshTokenStmt: %w", cerr)
 		}
 	}
+	if q.listAuditLogsByClientStmt != nil {
+		if cerr := q.listAuditLogsByClientStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAuditLogsByClientStmt: %w", cerr)
+		}
+	}
+	if q.listAuditLogsByEventTypeStmt != nil {
+		if cerr := q.listAuditLogsByEventTypeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAuditLogsByEventTypeStmt: %w", cerr)
+		}
+	}
+	if q.listAuditLogsByUserStmt != nil {
+		if cerr := q.listAuditLogsByUserStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listAuditLogsByUserStmt: %w", cerr)
+		}
+	}
 	if q.listClientsStmt != nil {
 		if cerr := q.listClientsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listClientsStmt: %w", cerr)
@@ -300,6 +332,7 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 type Queries struct {
 	db                                  DBTX
 	tx                                  *sql.Tx
+	createAuditLogStmt                  *sql.Stmt
 	createAuthorizationCodeStmt         *sql.Stmt
 	createClientStmt                    *sql.Stmt
 	createOIDCSessionStmt               *sql.Stmt
@@ -324,6 +357,9 @@ type Queries struct {
 	getTokenByAccessTokenStmt           *sql.Stmt
 	getTokenByIDStmt                    *sql.Stmt
 	getTokenByRefreshTokenStmt          *sql.Stmt
+	listAuditLogsByClientStmt           *sql.Stmt
+	listAuditLogsByEventTypeStmt        *sql.Stmt
+	listAuditLogsByUserStmt             *sql.Stmt
 	listClientsStmt                     *sql.Stmt
 	markAuthorizationCodeUsedStmt       *sql.Stmt
 	updateAuthorizationCodePKCEStmt     *sql.Stmt
@@ -335,6 +371,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
 		db:                                  tx,
 		tx:                                  tx,
+		createAuditLogStmt:                  q.createAuditLogStmt,
 		createAuthorizationCodeStmt:         q.createAuthorizationCodeStmt,
 		createClientStmt:                    q.createClientStmt,
 		createOIDCSessionStmt:               q.createOIDCSessionStmt,
@@ -359,6 +396,9 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
 		getTokenByIDStmt:                    q.getTokenByIDStmt,
 		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
+		listAuditLogsByClientStmt:           q.listAuditLogsByClientStmt,
+		listAuditLogsByEventTypeStmt:        q.listAuditLogsByEventTypeStmt,
+		listAuditLogsByUserStmt:             q.listAuditLogsByUserStmt,
 		listClientsStmt:                     q.listClientsStmt,
 		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
 		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -10,7 +10,20 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
+
+type AuditLog struct {
+	ID        uuid.UUID             `json:"id"`
+	EventType string                `json:"event_type"`
+	UserID    uuid.NullUUID         `json:"user_id"`
+	ClientID  uuid.NullUUID         `json:"client_id"`
+	SessionID sql.NullString        `json:"session_id"`
+	IpAddress sql.NullString        `json:"ip_address"`
+	UserAgent sql.NullString        `json:"user_agent"`
+	Details   pqtype.NullRawMessage `json:"details"`
+	CreatedAt time.Time             `json:"created_at"`
+}
 
 type AuthorizationCode struct {
 	Code                string         `json:"code"`

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -12,7 +12,48 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
+
+const createAuditLog = `-- name: CreateAuditLog :exec
+
+INSERT INTO audit_logs (
+    id,
+    event_type,
+    user_id,
+    client_id,
+    session_id,
+    ip_address,
+    user_agent,
+    details
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+`
+
+type CreateAuditLogParams struct {
+	ID        uuid.UUID             `json:"id"`
+	EventType string                `json:"event_type"`
+	UserID    uuid.NullUUID         `json:"user_id"`
+	ClientID  uuid.NullUUID         `json:"client_id"`
+	SessionID sql.NullString        `json:"session_id"`
+	IpAddress sql.NullString        `json:"ip_address"`
+	UserAgent sql.NullString        `json:"user_agent"`
+	Details   pqtype.NullRawMessage `json:"details"`
+}
+
+// Audit log queries
+func (q *Queries) CreateAuditLog(ctx context.Context, arg CreateAuditLogParams) error {
+	_, err := q.exec(ctx, q.createAuditLogStmt, createAuditLog,
+		arg.ID,
+		arg.EventType,
+		arg.UserID,
+		arg.ClientID,
+		arg.SessionID,
+		arg.IpAddress,
+		arg.UserAgent,
+		arg.Details,
+	)
+	return err
+}
 
 const createAuthorizationCode = `-- name: CreateAuthorizationCode :exec
 
@@ -419,6 +460,144 @@ func (q *Queries) GetTokenByRefreshToken(ctx context.Context, refreshToken sql.N
 		&i.CreatedAt,
 	)
 	return i, err
+}
+
+const listAuditLogsByClient = `-- name: ListAuditLogsByClient :many
+SELECT id, event_type, user_id, client_id, session_id, ip_address, user_agent, details, created_at FROM audit_logs
+WHERE client_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListAuditLogsByClientParams struct {
+	ClientID uuid.NullUUID `json:"client_id"`
+	Limit    int32         `json:"limit"`
+	Offset   int32         `json:"offset"`
+}
+
+func (q *Queries) ListAuditLogsByClient(ctx context.Context, arg ListAuditLogsByClientParams) ([]AuditLog, error) {
+	rows, err := q.query(ctx, q.listAuditLogsByClientStmt, listAuditLogsByClient, arg.ClientID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuditLog{}
+	for rows.Next() {
+		var i AuditLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.EventType,
+			&i.UserID,
+			&i.ClientID,
+			&i.SessionID,
+			&i.IpAddress,
+			&i.UserAgent,
+			&i.Details,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAuditLogsByEventType = `-- name: ListAuditLogsByEventType :many
+SELECT id, event_type, user_id, client_id, session_id, ip_address, user_agent, details, created_at FROM audit_logs
+WHERE event_type = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListAuditLogsByEventTypeParams struct {
+	EventType string `json:"event_type"`
+	Limit     int32  `json:"limit"`
+	Offset    int32  `json:"offset"`
+}
+
+func (q *Queries) ListAuditLogsByEventType(ctx context.Context, arg ListAuditLogsByEventTypeParams) ([]AuditLog, error) {
+	rows, err := q.query(ctx, q.listAuditLogsByEventTypeStmt, listAuditLogsByEventType, arg.EventType, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuditLog{}
+	for rows.Next() {
+		var i AuditLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.EventType,
+			&i.UserID,
+			&i.ClientID,
+			&i.SessionID,
+			&i.IpAddress,
+			&i.UserAgent,
+			&i.Details,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listAuditLogsByUser = `-- name: ListAuditLogsByUser :many
+SELECT id, event_type, user_id, client_id, session_id, ip_address, user_agent, details, created_at FROM audit_logs
+WHERE user_id = $1
+ORDER BY created_at DESC
+LIMIT $2 OFFSET $3
+`
+
+type ListAuditLogsByUserParams struct {
+	UserID uuid.NullUUID `json:"user_id"`
+	Limit  int32         `json:"limit"`
+	Offset int32         `json:"offset"`
+}
+
+func (q *Queries) ListAuditLogsByUser(ctx context.Context, arg ListAuditLogsByUserParams) ([]AuditLog, error) {
+	rows, err := q.query(ctx, q.listAuditLogsByUserStmt, listAuditLogsByUser, arg.UserID, arg.Limit, arg.Offset)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []AuditLog{}
+	for rows.Next() {
+		var i AuditLog
+		if err := rows.Scan(
+			&i.ID,
+			&i.EventType,
+			&i.UserID,
+			&i.ClientID,
+			&i.SessionID,
+			&i.IpAddress,
+			&i.UserAgent,
+			&i.Details,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listClients = `-- name: ListClients :many

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -12,6 +12,8 @@ import (
 )
 
 type Querier interface {
+	// Audit log queries
+	CreateAuditLog(ctx context.Context, arg CreateAuditLogParams) error
 	// Authorization Code queries
 	CreateAuthorizationCode(ctx context.Context, arg CreateAuthorizationCodeParams) error
 	// Client queries
@@ -40,6 +42,9 @@ type Querier interface {
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
+	ListAuditLogsByClient(ctx context.Context, arg ListAuditLogsByClientParams) ([]AuditLog, error)
+	ListAuditLogsByEventType(ctx context.Context, arg ListAuditLogsByEventTypeParams) ([]AuditLog, error)
+	ListAuditLogsByUser(ctx context.Context, arg ListAuditLogsByUserParams) ([]AuditLog, error)
 	ListClients(ctx context.Context) ([]Client, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error

--- a/internal/router/v1/auth.go
+++ b/internal/router/v1/auth.go
@@ -8,8 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 
+	"github.com/traPtitech/portal-oidc/internal/audit"
+	"github.com/traPtitech/portal-oidc/internal/domain"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -64,7 +67,15 @@ func (h *Handler) PostLogin(ctx *echo.Context) error {
 		userID, err = h.authenticatePortalUser(ctx, username, password)
 	}
 
+	ip, ua := audit.FromRequest(ctx.Request())
+
 	if err != nil {
+		h.auditLogger.Record(ctx.Request().Context(), audit.Event{
+			Type:      domain.AuditEventLoginFailure,
+			IPAddress: ip,
+			UserAgent: ua,
+			Details:   map[string]any{"username": username, "reason": err.Error()},
+		})
 		return ctx.HTML(http.StatusUnauthorized, `<!DOCTYPE html>
 <html>
 <head><title>Login Failed</title></head>
@@ -75,6 +86,18 @@ func (h *Handler) PostLogin(ctx *echo.Context) error {
 </body>
 </html>`)
 	}
+
+	uid, parseErr := uuid.Parse(userID)
+	var uidPtr *uuid.UUID
+	if parseErr == nil {
+		uidPtr = &uid
+	}
+	h.auditLogger.Record(ctx.Request().Context(), audit.Event{
+		Type:      domain.AuditEventLoginSuccess,
+		UserID:    uidPtr,
+		IPAddress: ip,
+		UserAgent: ua,
+	})
 
 	session, err := h.sessions.Get(ctx.Request(), sessionName)
 	if err != nil {

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 
+	"github.com/traPtitech/portal-oidc/internal/audit"
 	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
@@ -179,7 +180,9 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
+	auditLogger := audit.NewLogger(repository.NewAuditLogRepository(queries))
+
+	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, auditLogger, OAuthConfig{
 		Issuer:      "http://localhost:8080",
 		Environment: "development",
 		TestUserID:  "00000000-0000-0000-0000-000000000000",

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/audit"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -17,6 +18,7 @@ type Handler struct {
 	oauth2        fosite.OAuth2Provider
 	userUseCase   usecase.UserUseCase
 	sessions      *sessions.CookieStore
+	auditLogger   *audit.Logger
 	config        OAuthConfig
 }
 
@@ -33,6 +35,7 @@ func NewHandler(
 	oauthUseCase usecase.OAuthUseCase,
 	oauth2 fosite.OAuth2Provider,
 	userUseCase usecase.UserUseCase,
+	auditLogger *audit.Logger,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -50,6 +53,7 @@ func NewHandler(
 		oauth2:        oauth2,
 		userUseCase:   userUseCase,
 		sessions:      store,
+		auditLogger:   auditLogger,
 		config:        config,
 	}
 }

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -15,6 +15,8 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/audit"
+	"github.com/traPtitech/portal-oidc/internal/domain"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/router/v1/gen"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
@@ -176,8 +178,37 @@ func (h *Handler) Token(ctx *echo.Context) error {
 		return nil
 	}
 
+	ip, ua := audit.FromRequest(req)
+	grantTypes := accessRequest.GetGrantTypes()
+	var grantType string
+	if len(grantTypes) > 0 {
+		grantType = grantTypes[0]
+	}
+	h.auditLogger.Record(c, audit.Event{
+		Type:      domain.AuditEventTokenIssued,
+		UserID:    parseAuditUUID(accessRequest.GetSession().GetSubject()),
+		ClientID:  parseAuditUUID(accessRequest.GetClient().GetID()),
+		IPAddress: ip,
+		UserAgent: ua,
+		Details: map[string]any{
+			"grant_type": grantType,
+			"scopes":     accessRequest.GetGrantedScopes(),
+		},
+	})
+
 	h.oauth2.WriteAccessResponse(c, rw, accessRequest, response)
 	return nil
+}
+
+// parseAuditUUID returns a *uuid.UUID for audit attribution. Anything that
+// fails to parse (anonymous client, missing subject, ...) becomes nil so the
+// audit_logs row records "no subject" rather than fabricating uuid.Nil.
+func parseAuditUUID(s string) *uuid.UUID {
+	id, err := uuid.Parse(s)
+	if err != nil || id == uuid.Nil {
+		return nil
+	}
+	return &id
 }
 
 func (h *Handler) GetUserInfo(ctx *echo.Context) error {


### PR DESCRIPTION
## 概要

traPortal v2 仕様の \`audit_logs\` テーブルと、それを書き込む \`internal/audit\` パッケージを追加。既存エンドポイントで発生するセキュリティ関連イベント (login 成功/失敗、token 発行) を最初に対応。

## 背景

仕様の \`audit_logs\` テーブル設計:
| カラム | 型 | 説明 |
|---|---|---|
| id | UUID | PK |
| event_type | TEXT | 例 \`auth.login.success\`, \`token.issued\` |
| user_id | UUID NULL | FK 対象ユーザー (匿名イベントは NULL) |
| client_id | UUID NULL | FK 対象クライアント |
| session_id | TEXT NULL | |
| ip_address | TEXT NULL | X-Forwarded-For 先頭優先 |
| user_agent | TEXT NULL | |
| details | JSONB NULL | 自由形式 (event 種別ごとに異なる) |
| created_at | TIMESTAMPTZ | |

監査ログは **append-only**。失敗時はログに残すだけで request は失敗させない (logging 失敗で本番 request を落とすほうがリスク高)。

## 変更

### スキーマ・クエリ
- \`db/schema.sql\`: \`audit_logs\` テーブル + 4 つの index (event_type, user_id, client_id, created_at)
- \`db/query/oidc.sql\`: \`CreateAuditLog\` / \`ListAuditLogsByUser/Client/EventType\`
- \`internal/repository/oidc/*\`: sqlc 自動生成

### Domain / Repository
- \`internal/domain/audit.go\`: \`AuditLog\` + \`AuditEventType\` enum (login.success, token.issued, client.created 等 10 種類)
- \`internal/repository/audit.go\`: \`AuditLogRepository\` 実装。最も選択性の高いフィルタで分岐
- \`nullUUID\` / \`nullString\` ヘルパーを repository.go に再追加 (PR #135 と一時的に二重持ち。先にマージされた側を削除する想定)

### audit パッケージ (新規)
- \`internal/audit/logger.go\`:
  - \`Logger.Record\`: best-effort で記録、失敗は \`log.Printf\` のみ
  - \`Event\` 構造体で必要最低限を渡すだけで OK
  - \`FromRequest\`: X-Forwarded-For 先頭 → RemoteAddr のフォールバックで IP 取得

### Wiring
- \`cmd/serve.go\`: \`audit.Logger\` を構築して handler に注入
- \`internal/router/v1/handler.go\`: \`Handler.auditLogger\` フィールド追加
- \`internal/router/v1/auth.go\`:
  - \`PostLogin\` 成功時 → \`auth.login.success\` (user_id 付き)
  - \`PostLogin\` 失敗時 → \`auth.login.failure\` (username + reason を details に)
- \`internal/router/v1/oauth.go\`:
  - \`Token\` 成功時 → \`token.issued\` (grant_type, scopes を details に)
- \`internal/router/v1/client_test.go\`: \`auditLogger\` 注入

## 後続 PR

このブランチでは login + token のみ対応。他のエンドポイントは各ブランチに audit hook を追加して PR を分ける:
- \`/oauth2/revoke\` (PR #132 に hook 追加)
- \`/oauth2/introspect\` (PR #133 に hook 追加)
- \`/oauth2/logout\` (PR #134 に hook 追加)
- \`/api/v1/admin/clients\` CRUD (新規 PR)
- \`signing_key.rotated\` (PR #136 に hook 追加)

加えて: 監査ログ閲覧の admin API (\`GET /api/v1/admin/audit-logs\`) も別 PR。

## RFC / 仕様根拠

| 項目 | 仕様 |
|---|---|
| audit_logs テーブル | traPortal v2 仕様 |
| ログ管理ベストプラクティス | [NIST SP 800-92](https://csrc.nist.gov/pubs/sp/800/92/final) |

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)