### PR TITLE
feat(consent): user_consents テーブル + /oauth2/consent 同意画面

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -60,11 +60,13 @@ func newServer(cfg Config) (http.Handler, error) {
 		}
 		userUseCase = usecase.NewUserUseCase(repository.NewUserRepository(portalQueries))
 	}
+	consentRepo := repository.NewUserConsentRepository(queries)
 	handler := v1.NewHandler(
 		usecase.NewClientUseCase(clientRepo),
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
 		userUseCase,
+		consentRepo,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),
@@ -82,6 +84,8 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.GET("/oauth2/consent", handler.GetConsent)
+	e.POST("/oauth2/consent", handler.PostConsent)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,29 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- User consent queries
+
+-- name: UpsertUserConsent :exec
+-- Re-grant a user's consent to a client. Overwrites the existing scope set
+-- and clears any prior revocation so subsequent authorize requests succeed.
+INSERT INTO user_consents (id, user_id, client_id, scopes, granted_at, revoked_at)
+VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, NULL)
+ON CONFLICT (user_id, client_id)
+DO UPDATE SET
+    scopes = EXCLUDED.scopes,
+    granted_at = EXCLUDED.granted_at,
+    revoked_at = NULL;
+
+-- name: GetUserConsent :one
+SELECT * FROM user_consents
+WHERE user_id = $1 AND client_id = $2;
+
+-- name: ListUserConsentsByUser :many
+SELECT * FROM user_consents
+WHERE user_id = $1 AND revoked_at IS NULL;
+
+-- name: RevokeUserConsent :exec
+UPDATE user_consents
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE user_id = $1 AND client_id = $2;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,23 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §user_consents
+-- Persists which scopes a user has granted to which client. The (user_id,
+-- client_id) UNIQUE constraint enforces a single live consent per pair: a new
+-- grant overwrites the prior set rather than accumulating duplicates.
+CREATE TABLE IF NOT EXISTS user_consents (
+  id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  client_id UUID NOT NULL,
+  scopes JSONB NOT NULL,
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMPTZ NULL,
+  revoked_at TIMESTAMPTZ NULL,
+  PRIMARY KEY (id),
+  CONSTRAINT idx_user_consents_user_client UNIQUE (user_id, client_id),
+  CONSTRAINT fk_user_consents_client FOREIGN KEY (client_id)
+    REFERENCES clients (client_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_consents_user_id ON user_consents (user_id);

--- a/internal/domain/consent.go
+++ b/internal/domain/consent.go
@@ -1,0 +1,48 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserConsent records the OAuth scopes a user has granted to a particular
+// client. There is at most one row per (UserID, ClientID); a fresh grant
+// replaces the prior scope set.
+type UserConsent struct {
+	ID        uuid.UUID
+	UserID    uuid.UUID
+	ClientID  uuid.UUID
+	Scopes    []string
+	GrantedAt time.Time
+	ExpiresAt *time.Time
+	RevokedAt *time.Time
+}
+
+// IsActive reports whether the consent should still be honoured. A consent is
+// inactive once revoked or after its expiry (when set).
+func (c UserConsent) IsActive(now time.Time) bool {
+	if c.RevokedAt != nil {
+		return false
+	}
+	if c.ExpiresAt != nil && !now.Before(*c.ExpiresAt) {
+		return false
+	}
+	return true
+}
+
+// Covers returns true when every scope in needed is contained in the
+// consent's scope set. Used to decide whether to skip the consent screen on a
+// repeat authorization.
+func (c UserConsent) Covers(needed []string) bool {
+	have := make(map[string]struct{}, len(c.Scopes))
+	for _, s := range c.Scopes {
+		have[s] = struct{}{}
+	}
+	for _, s := range needed {
+		if _, ok := have[s]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/repository/consent.go
+++ b/internal/repository/consent.go
@@ -1,0 +1,109 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+var ErrUserConsentNotFound = errors.New("user consent not found")
+
+type UserConsentRepository interface {
+	Upsert(ctx context.Context, consent domain.UserConsent) error
+	Get(ctx context.Context, userID, clientID uuid.UUID) (domain.UserConsent, error)
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]domain.UserConsent, error)
+	Revoke(ctx context.Context, userID, clientID uuid.UUID) error
+}
+
+type userConsentRepository struct {
+	queries *oidc.Queries
+}
+
+func NewUserConsentRepository(queries *oidc.Queries) UserConsentRepository {
+	return &userConsentRepository{queries: queries}
+}
+
+func (r *userConsentRepository) Upsert(ctx context.Context, consent domain.UserConsent) error {
+	scopes, err := json.Marshal(consent.Scopes)
+	if err != nil {
+		return err
+	}
+	id := consent.ID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
+	return r.queries.UpsertUserConsent(ctx, oidc.UpsertUserConsentParams{
+		ID:       id,
+		UserID:   consent.UserID,
+		ClientID: consent.ClientID,
+		Scopes:   scopes,
+	})
+}
+
+func (r *userConsentRepository) Get(ctx context.Context, userID, clientID uuid.UUID) (domain.UserConsent, error) {
+	row, err := r.queries.GetUserConsent(ctx, oidc.GetUserConsentParams{
+		UserID:   userID,
+		ClientID: clientID,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.UserConsent{}, ErrUserConsentNotFound
+		}
+		return domain.UserConsent{}, err
+	}
+	return toDomainUserConsent(row)
+}
+
+func (r *userConsentRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]domain.UserConsent, error) {
+	rows, err := r.queries.ListUserConsentsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.UserConsent, 0, len(rows))
+	for _, row := range rows {
+		c, err := toDomainUserConsent(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, nil
+}
+
+func (r *userConsentRepository) Revoke(ctx context.Context, userID, clientID uuid.UUID) error {
+	return r.queries.RevokeUserConsent(ctx, oidc.RevokeUserConsentParams{
+		UserID:   userID,
+		ClientID: clientID,
+	})
+}
+
+func toDomainUserConsent(row oidc.UserConsent) (domain.UserConsent, error) {
+	var scopes []string
+	if len(row.Scopes) > 0 {
+		if err := json.Unmarshal(row.Scopes, &scopes); err != nil {
+			return domain.UserConsent{}, err
+		}
+	}
+	consent := domain.UserConsent{
+		ID:        row.ID,
+		UserID:    row.UserID,
+		ClientID:  row.ClientID,
+		Scopes:    scopes,
+		GrantedAt: row.GrantedAt,
+	}
+	if row.ExpiresAt.Valid {
+		t := row.ExpiresAt.Time
+		consent.ExpiresAt = &t
+	}
+	if row.RevokedAt.Valid {
+		t := row.RevokedAt.Time
+		consent.RevokedAt = &t
+	}
+	return consent, nil
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -96,11 +96,20 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getTokenByRefreshTokenStmt, err = db.PrepareContext(ctx, getTokenByRefreshToken); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTokenByRefreshToken: %w", err)
 	}
+	if q.getUserConsentStmt, err = db.PrepareContext(ctx, getUserConsent); err != nil {
+		return nil, fmt.Errorf("error preparing query GetUserConsent: %w", err)
+	}
 	if q.listClientsStmt, err = db.PrepareContext(ctx, listClients); err != nil {
 		return nil, fmt.Errorf("error preparing query ListClients: %w", err)
 	}
+	if q.listUserConsentsByUserStmt, err = db.PrepareContext(ctx, listUserConsentsByUser); err != nil {
+		return nil, fmt.Errorf("error preparing query ListUserConsentsByUser: %w", err)
+	}
 	if q.markAuthorizationCodeUsedStmt, err = db.PrepareContext(ctx, markAuthorizationCodeUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkAuthorizationCodeUsed: %w", err)
+	}
+	if q.revokeUserConsentStmt, err = db.PrepareContext(ctx, revokeUserConsent); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeUserConsent: %w", err)
 	}
 	if q.updateAuthorizationCodePKCEStmt, err = db.PrepareContext(ctx, updateAuthorizationCodePKCE); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAuthorizationCodePKCE: %w", err)
@@ -110,6 +119,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.updateClientSecretStmt, err = db.PrepareContext(ctx, updateClientSecret); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateClientSecret: %w", err)
+	}
+	if q.upsertUserConsentStmt, err = db.PrepareContext(ctx, upsertUserConsent); err != nil {
+		return nil, fmt.Errorf("error preparing query UpsertUserConsent: %w", err)
 	}
 	return &q, nil
 }
@@ -236,14 +248,29 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getTokenByRefreshTokenStmt: %w", cerr)
 		}
 	}
+	if q.getUserConsentStmt != nil {
+		if cerr := q.getUserConsentStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getUserConsentStmt: %w", cerr)
+		}
+	}
 	if q.listClientsStmt != nil {
 		if cerr := q.listClientsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listClientsStmt: %w", cerr)
 		}
 	}
+	if q.listUserConsentsByUserStmt != nil {
+		if cerr := q.listUserConsentsByUserStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listUserConsentsByUserStmt: %w", cerr)
+		}
+	}
 	if q.markAuthorizationCodeUsedStmt != nil {
 		if cerr := q.markAuthorizationCodeUsedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markAuthorizationCodeUsedStmt: %w", cerr)
+		}
+	}
+	if q.revokeUserConsentStmt != nil {
+		if cerr := q.revokeUserConsentStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeUserConsentStmt: %w", cerr)
 		}
 	}
 	if q.updateAuthorizationCodePKCEStmt != nil {
@@ -259,6 +286,11 @@ func (q *Queries) Close() error {
 	if q.updateClientSecretStmt != nil {
 		if cerr := q.updateClientSecretStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateClientSecretStmt: %w", cerr)
+		}
+	}
+	if q.upsertUserConsentStmt != nil {
+		if cerr := q.upsertUserConsentStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing upsertUserConsentStmt: %w", cerr)
 		}
 	}
 	return err
@@ -324,11 +356,15 @@ type Queries struct {
 	getTokenByAccessTokenStmt           *sql.Stmt
 	getTokenByIDStmt                    *sql.Stmt
 	getTokenByRefreshTokenStmt          *sql.Stmt
+	getUserConsentStmt                  *sql.Stmt
 	listClientsStmt                     *sql.Stmt
+	listUserConsentsByUserStmt          *sql.Stmt
 	markAuthorizationCodeUsedStmt       *sql.Stmt
+	revokeUserConsentStmt               *sql.Stmt
 	updateAuthorizationCodePKCEStmt     *sql.Stmt
 	updateClientStmt                    *sql.Stmt
 	updateClientSecretStmt              *sql.Stmt
+	upsertUserConsentStmt               *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
@@ -359,10 +395,14 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
 		getTokenByIDStmt:                    q.getTokenByIDStmt,
 		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
+		getUserConsentStmt:                  q.getUserConsentStmt,
 		listClientsStmt:                     q.listClientsStmt,
+		listUserConsentsByUserStmt:          q.listUserConsentsByUserStmt,
 		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
+		revokeUserConsentStmt:               q.revokeUserConsentStmt,
 		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,
 		updateClientStmt:                    q.updateClientStmt,
 		updateClientSecretStmt:              q.updateClientSecretStmt,
+		upsertUserConsentStmt:               q.upsertUserConsentStmt,
 	}
 }

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -58,3 +58,13 @@ type Token struct {
 	ExpiresAt    time.Time      `json:"expires_at"`
 	CreatedAt    time.Time      `json:"created_at"`
 }
+
+type UserConsent struct {
+	ID        uuid.UUID       `json:"id"`
+	UserID    uuid.UUID       `json:"user_id"`
+	ClientID  uuid.UUID       `json:"client_id"`
+	Scopes    json.RawMessage `json:"scopes"`
+	GrantedAt time.Time       `json:"granted_at"`
+	ExpiresAt sql.NullTime    `json:"expires_at"`
+	RevokedAt sql.NullTime    `json:"revoked_at"`
+}

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -421,6 +421,31 @@ func (q *Queries) GetTokenByRefreshToken(ctx context.Context, refreshToken sql.N
 	return i, err
 }
 
+const getUserConsent = `-- name: GetUserConsent :one
+SELECT id, user_id, client_id, scopes, granted_at, expires_at, revoked_at FROM user_consents
+WHERE user_id = $1 AND client_id = $2
+`
+
+type GetUserConsentParams struct {
+	UserID   uuid.UUID `json:"user_id"`
+	ClientID uuid.UUID `json:"client_id"`
+}
+
+func (q *Queries) GetUserConsent(ctx context.Context, arg GetUserConsentParams) (UserConsent, error) {
+	row := q.queryRow(ctx, q.getUserConsentStmt, getUserConsent, arg.UserID, arg.ClientID)
+	var i UserConsent
+	err := row.Scan(
+		&i.ID,
+		&i.UserID,
+		&i.ClientID,
+		&i.Scopes,
+		&i.GrantedAt,
+		&i.ExpiresAt,
+		&i.RevokedAt,
+	)
+	return i, err
+}
+
 const listClients = `-- name: ListClients :many
 SELECT client_id, client_secret_hash, name, client_type, redirect_uris, created_at, updated_at FROM clients
 `
@@ -456,12 +481,64 @@ func (q *Queries) ListClients(ctx context.Context) ([]Client, error) {
 	return items, nil
 }
 
+const listUserConsentsByUser = `-- name: ListUserConsentsByUser :many
+SELECT id, user_id, client_id, scopes, granted_at, expires_at, revoked_at FROM user_consents
+WHERE user_id = $1 AND revoked_at IS NULL
+`
+
+func (q *Queries) ListUserConsentsByUser(ctx context.Context, userID uuid.UUID) ([]UserConsent, error) {
+	rows, err := q.query(ctx, q.listUserConsentsByUserStmt, listUserConsentsByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserConsent{}
+	for rows.Next() {
+		var i UserConsent
+		if err := rows.Scan(
+			&i.ID,
+			&i.UserID,
+			&i.ClientID,
+			&i.Scopes,
+			&i.GrantedAt,
+			&i.ExpiresAt,
+			&i.RevokedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markAuthorizationCodeUsed = `-- name: MarkAuthorizationCodeUsed :exec
 UPDATE authorization_codes SET used = TRUE WHERE code = $1
 `
 
 func (q *Queries) MarkAuthorizationCodeUsed(ctx context.Context, code string) error {
 	_, err := q.exec(ctx, q.markAuthorizationCodeUsedStmt, markAuthorizationCodeUsed, code)
+	return err
+}
+
+const revokeUserConsent = `-- name: RevokeUserConsent :exec
+UPDATE user_consents
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE user_id = $1 AND client_id = $2
+`
+
+type RevokeUserConsentParams struct {
+	UserID   uuid.UUID `json:"user_id"`
+	ClientID uuid.UUID `json:"client_id"`
+}
+
+func (q *Queries) RevokeUserConsent(ctx context.Context, arg RevokeUserConsentParams) error {
+	_, err := q.exec(ctx, q.revokeUserConsentStmt, revokeUserConsent, arg.UserID, arg.ClientID)
 	return err
 }
 
@@ -521,5 +598,36 @@ type UpdateClientSecretParams struct {
 
 func (q *Queries) UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error {
 	_, err := q.exec(ctx, q.updateClientSecretStmt, updateClientSecret, arg.ClientSecretHash, arg.ClientID)
+	return err
+}
+
+const upsertUserConsent = `-- name: UpsertUserConsent :exec
+
+INSERT INTO user_consents (id, user_id, client_id, scopes, granted_at, revoked_at)
+VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP, NULL)
+ON CONFLICT (user_id, client_id)
+DO UPDATE SET
+    scopes = EXCLUDED.scopes,
+    granted_at = EXCLUDED.granted_at,
+    revoked_at = NULL
+`
+
+type UpsertUserConsentParams struct {
+	ID       uuid.UUID       `json:"id"`
+	UserID   uuid.UUID       `json:"user_id"`
+	ClientID uuid.UUID       `json:"client_id"`
+	Scopes   json.RawMessage `json:"scopes"`
+}
+
+// User consent queries
+// Re-grant a user's consent to a client. Overwrites the existing scope set
+// and clears any prior revocation so subsequent authorize requests succeed.
+func (q *Queries) UpsertUserConsent(ctx context.Context, arg UpsertUserConsentParams) error {
+	_, err := q.exec(ctx, q.upsertUserConsentStmt, upsertUserConsent,
+		arg.ID,
+		arg.UserID,
+		arg.ClientID,
+		arg.Scopes,
+	)
 	return err
 }

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -40,11 +40,18 @@ type Querier interface {
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
+	GetUserConsent(ctx context.Context, arg GetUserConsentParams) (UserConsent, error)
 	ListClients(ctx context.Context) ([]Client, error)
+	ListUserConsentsByUser(ctx context.Context, userID uuid.UUID) ([]UserConsent, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
+	RevokeUserConsent(ctx context.Context, arg RevokeUserConsentParams) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error
 	UpdateClient(ctx context.Context, arg UpdateClientParams) error
 	UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error
+	// User consent queries
+	// Re-grant a user's consent to a client. Overwrites the existing scope set
+	// and clears any prior revocation so subsequent authorize requests succeed.
+	UpsertUserConsent(ctx context.Context, arg UpsertUserConsentParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -179,7 +179,9 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
+	consentRepo := repository.NewUserConsentRepository(queries)
+
+	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, consentRepo, OAuthConfig{
 		Issuer:      "http://localhost:8080",
 		Environment: "development",
 		TestUserID:  "00000000-0000-0000-0000-000000000000",

--- a/internal/router/v1/consent.go
+++ b/internal/router/v1/consent.go
@@ -1,0 +1,140 @@
+package v1
+
+import (
+	"html"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+)
+
+// GetConsent renders the consent confirmation page for the in-flight authorize
+// request encoded in return_url. The page lists the scopes the client is
+// requesting and offers approve/deny buttons that submit to PostConsent.
+//
+// Refs:
+//   - OIDC Core 1.0 §3.1.2.4 (Authorization Server Obtains End-User Consent)
+//     https://openid.net/specs/openid-connect-core-1_0.html#Consent
+func (h *Handler) GetConsent(ctx *echo.Context) error {
+	returnURL := sanitizeReturnURL(ctx.QueryParam("return_url"))
+	authParams, err := url.ParseRequestURI(returnURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid return_url")
+	}
+	q := authParams.Query()
+	clientID := q.Get("client_id")
+	scope := q.Get("scope")
+	scopes := splitScope(scope)
+
+	clientName := clientID
+	if cid, perr := uuid.Parse(clientID); perr == nil && h.clientUseCase != nil {
+		if c, gerr := h.clientUseCase.Get(ctx.Request().Context(), cid); gerr == nil {
+			clientName = c.Name
+		}
+	}
+
+	scopeItems := ""
+	for _, s := range scopes {
+		scopeItems += "<li>" + html.EscapeString(s) + "</li>"
+	}
+
+	page := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Authorize</title>
+    <style>
+        body { font-family: sans-serif; max-width: 480px; margin: 80px auto; padding: 20px; }
+        h1 { font-size: 20px; }
+        ul { background: #f5f5f5; padding: 12px 32px; border-radius: 6px; }
+        form { display: flex; gap: 12px; margin-top: 20px; }
+        button { flex: 1; padding: 12px; font-size: 16px; border: none; border-radius: 4px; cursor: pointer; }
+        button.allow { background: #007bff; color: white; }
+        button.deny { background: #e0e0e0; }
+    </style>
+</head>
+<body>
+    <h1>` + html.EscapeString(clientName) + ` is requesting access</h1>
+    <p>This application would like to access the following:</p>
+    <ul>` + scopeItems + `</ul>
+    <form method="POST" action="/oauth2/consent">
+        <input type="hidden" name="return_url" value="` + html.EscapeString(returnURL) + `">
+        <button class="deny" type="submit" name="action" value="deny">Deny</button>
+        <button class="allow" type="submit" name="action" value="allow">Allow</button>
+    </form>
+</body>
+</html>`
+	return ctx.HTML(http.StatusOK, page)
+}
+
+// PostConsent persists (or revokes) the user's decision and either bounces
+// back to the authorize URL or, on denial, sends the access_denied error
+// straight to the redirect_uri.
+func (h *Handler) PostConsent(ctx *echo.Context) error {
+	action := ctx.FormValue("action")
+	returnURL := sanitizeReturnURL(ctx.FormValue("return_url"))
+
+	authParams, err := url.ParseRequestURI(returnURL)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid return_url")
+	}
+	q := authParams.Query()
+
+	if action == "deny" {
+		redirectURI := q.Get("redirect_uri")
+		state := q.Get("state")
+		if redirectURI == "" {
+			return ctx.HTML(http.StatusForbidden, `<h1>Access denied</h1>`)
+		}
+		dest, perr := url.Parse(redirectURI)
+		if perr != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "invalid redirect_uri")
+		}
+		dq := dest.Query()
+		dq.Set("error", "access_denied")
+		dq.Set("error_description", "The user denied the authorization request.")
+		if state != "" {
+			dq.Set("state", state)
+		}
+		dest.RawQuery = dq.Encode()
+		return ctx.Redirect(http.StatusFound, dest.String())
+	}
+
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid session user")
+	}
+	clientID, err := uuid.Parse(q.Get("client_id"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid client_id")
+	}
+	scopes := splitScope(q.Get("scope"))
+
+	if err := h.consents.Upsert(ctx.Request().Context(), domain.UserConsent{
+		UserID:   userID,
+		ClientID: clientID,
+		Scopes:   scopes,
+	}); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to record consent")
+	}
+
+	return ctx.Redirect(http.StatusFound, returnURL)
+}
+
+func splitScope(scope string) []string {
+	if scope == "" {
+		return nil
+	}
+	out := strings.Fields(scope)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -16,6 +17,7 @@ type Handler struct {
 	oauthUseCase  usecase.OAuthUseCase
 	oauth2        fosite.OAuth2Provider
 	userUseCase   usecase.UserUseCase
+	consents      repository.UserConsentRepository
 	sessions      *sessions.CookieStore
 	config        OAuthConfig
 }
@@ -33,6 +35,7 @@ func NewHandler(
 	oauthUseCase usecase.OAuthUseCase,
 	oauth2 fosite.OAuth2Provider,
 	userUseCase usecase.UserUseCase,
+	consents repository.UserConsentRepository,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -49,6 +52,7 @@ func NewHandler(
 		oauthUseCase:  oauthUseCase,
 		oauth2:        oauth2,
 		userUseCase:   userUseCase,
+		consents:      consents,
 		sessions:      store,
 		config:        config,
 	}

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"errors"
@@ -15,6 +16,7 @@ import (
 	"github.com/labstack/echo/v5"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
 	"github.com/traPtitech/portal-oidc/internal/router/v1/gen"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
@@ -77,7 +79,58 @@ func (h *Handler) authorize(ctx *echo.Context) error {
 		authTime = time.Now()
 	}
 
+	// Consent check is enforced only in production. Dev keeps the legacy
+	// auto-grant behaviour so the conformance suite (which does not yet drive
+	// a consent UI) still completes its flows.
+	if h.config.Environment == "production" && h.consents != nil {
+		needConsent, err := h.consentRequired(c, ar, userID)
+		if err != nil {
+			h.oauth2.WriteAuthorizeError(c, rw, ar, fosite.ErrServerError.WithDebug(err.Error()))
+			return nil
+		}
+		if needConsent {
+			if ar.GetRequestForm().Get("prompt") == "none" {
+				h.oauth2.WriteAuthorizeError(c, rw, ar, fosite.ErrConsentRequired)
+				return nil
+			}
+			return h.redirectToConsent(ctx, &returnURL)
+		}
+	}
+
 	return h.completeAuthorize(ctx, ar, userID, authTime)
+}
+
+// consentRequired returns true when no active consent exists for the
+// (user, client) pair that covers every scope being requested. prompt=consent
+// always forces a fresh consent screen per OIDC Core 1.0 §3.1.2.1.
+func (h *Handler) consentRequired(ctx context.Context, ar fosite.AuthorizeRequester, userIDStr string) (bool, error) {
+	if ar.GetRequestForm().Get("prompt") == "consent" {
+		return true, nil
+	}
+	userID, parseErr := uuid.Parse(userIDStr)
+	if parseErr != nil {
+		// Bad session subject ⇒ ask the user again rather than blindly trusting it.
+		return true, nil //nolint:nilerr // intentional: degrade to consent prompt
+	}
+	clientID, parseErr := uuid.Parse(ar.GetClient().GetID())
+	if parseErr != nil {
+		return true, nil //nolint:nilerr // intentional: unparseable client → re-prompt
+	}
+	consent, err := h.consents.Get(ctx, userID, clientID)
+	if err != nil {
+		if errors.Is(err, repository.ErrUserConsentNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+	if !consent.IsActive(time.Now()) {
+		return true, nil
+	}
+	return !consent.Covers([]string(ar.GetRequestedScopes())), nil
+}
+
+func (h *Handler) redirectToConsent(ctx *echo.Context, returnURL *url.URL) error {
+	return ctx.Redirect(http.StatusFound, "/oauth2/consent?return_url="+url.QueryEscape(returnURL.String()))
 }
 
 func (h *Handler) completeAuthorize(ctx *echo.Context, ar fosite.AuthorizeRequester, userID string, authTime time.Time) error {


### PR DESCRIPTION
## 概要

OIDC Core 1.0 §3.1.2.4 準拠の End-User 同意フローを実装。\`/oauth2/consent\` 同意画面とその裏側の \`user_consents\` 永続化を追加する。

## 背景

仕様の \`user_consents\` テーブル設計:
| カラム | 型 |
|---|---|
| id | UUID PK |
| user_id | UUID NOT NULL |
| client_id | UUID NOT NULL |
| scopes | JSONB |
| granted_at | TIMESTAMPTZ |
| expires_at | TIMESTAMPTZ NULL |
| revoked_at | TIMESTAMPTZ NULL |
| UNIQUE(user_id, client_id) | (再付与は overwrite) |

## 動作フロー

1. authorize handler がログイン済みを確認
2. \`UserConsent.Covers(requestedScopes)\` で「全スコープを既に同意済みか」確認
3. 未同意 / 失効済 / \`prompt=consent\` の場合 → \`/oauth2/consent?return_url=<authorize URL>\` へ 302
4. ユーザが Allow → \`UserConsent\` upsert → authorize URL へ戻して再開
5. ユーザが Deny → \`redirect_uri?error=access_denied\` へリダイレクト
6. \`prompt=none\` で未同意の場合 → \`consent_required\` エラーを返却

## 変更

### スキーマ・クエリ
- \`db/schema.sql\`: \`user_consents\` テーブル + UNIQUE (user_id, client_id) + ON DELETE CASCADE from clients
- \`db/query/oidc.sql\`: \`UpsertUserConsent\` (ON CONFLICT で再付与を一発)、Get/List/Revoke
- \`internal/repository/oidc/*\`: sqlc 自動生成

### Domain / Repository
- \`internal/domain/consent.go\`: \`UserConsent\` 構造体 + \`IsActive\` / \`Covers\` ヘルパー
- \`internal/repository/consent.go\`: \`UserConsentRepository\` 実装

### Handler
- \`internal/router/v1/oauth.go\`:
  - \`consentRequired\` ヘルパーで判定
  - authorize 完了直前に consent チェックを差し込み
  - \`prompt=none\` + 未同意 → \`fosite.ErrConsentRequired\`
- \`internal/router/v1/consent.go\` (新規):
  - \`GetConsent\`: 同意画面 HTML
  - \`PostConsent\`: allow → upsert → return_url、deny → \`redirect_uri\` に \`error=access_denied\` で返却
- \`internal/router/v1/handler.go\`: \`consents\` フィールド追加
- \`cmd/serve.go\`: \`UserConsentRepository\` 注入 + ルート登録

### Environment ガード
本 PR では \`Environment == "production"\` のみ consent チェックを走らせる。dev / conformance は依然として \`IsNonProd\` ショートカットでバイパスされる。

PR #128 (real auth flow) マージ後に follow-up:
- testuser を auto-consent するか
- conformance script に consent フォーム送信ロジックを追加するか

## RFC / 仕様根拠

| 項目 | 仕様 | 該当条 |
|---|---|---|
| End-User Consent | OIDC Core 1.0 | [§3.1.2.4](https://openid.net/specs/openid-connect-core-1_0.html#Consent) |
| consent_required / access_denied | OIDC Core 1.0 | [§3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError) |
| user_consents テーブル | traPortal v2 仕様 | |

## 後続 PR
- 同意管理 admin API \`GET /api/v1/users/me/consents\` / \`DELETE /api/v1/users/me/consents/{client_id}\`
- conformance auto-consent

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)