### PR TITLE
feat(sessions): user_sessions テーブル + /auth/sessions API

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -60,11 +60,13 @@ func newServer(cfg Config) (http.Handler, error) {
 		}
 		userUseCase = usecase.NewUserUseCase(repository.NewUserRepository(portalQueries))
 	}
+	userSessionRepo := repository.NewUserSessionRepository(queries)
 	handler := v1.NewHandler(
 		usecase.NewClientUseCase(clientRepo),
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
 		userUseCase,
+		userSessionRepo,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),
@@ -82,6 +84,10 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.GET("/auth/session", handler.GetSession)
+	e.GET("/auth/sessions", handler.ListSessions)
+	e.DELETE("/auth/sessions", handler.RevokeAllOtherSessions)
+	e.DELETE("/auth/sessions/:sessionId", handler.RevokeSession)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,41 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- User session queries
+
+-- name: CreateUserSession :exec
+INSERT INTO user_sessions (
+    id,
+    session_id,
+    user_id,
+    user_agent,
+    ip_address,
+    acr,
+    amr,
+    auth_time,
+    expires_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+
+-- name: GetUserSessionBySessionID :one
+SELECT * FROM user_sessions WHERE session_id = $1;
+
+-- name: ListUserSessionsByUser :many
+SELECT * FROM user_sessions
+WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > CURRENT_TIMESTAMP
+ORDER BY last_active_at DESC;
+
+-- name: TouchUserSession :exec
+UPDATE user_sessions
+SET last_active_at = CURRENT_TIMESTAMP
+WHERE session_id = $1;
+
+-- name: RevokeUserSession :exec
+UPDATE user_sessions
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND user_id = $2;
+
+-- name: RevokeAllUserSessionsExcept :exec
+UPDATE user_sessions
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE user_id = $1 AND session_id <> $2 AND revoked_at IS NULL;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,28 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §sessions
+-- Server-side login session metadata. session_id is the random opaque value
+-- stored in the End-User's cookie. Multiple rows per user_id correspond to
+-- separate browsers / devices; revoked_at lets the user (or an admin)
+-- terminate one without waiting for natural expiry.
+CREATE TABLE IF NOT EXISTS user_sessions (
+  id UUID NOT NULL,
+  session_id TEXT NOT NULL,
+  user_id UUID NOT NULL,
+  user_agent TEXT NULL,
+  ip_address TEXT NULL,
+  acr TEXT NULL,
+  amr JSONB NULL,
+  auth_time TIMESTAMPTZ NOT NULL,
+  last_active_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT idx_user_sessions_session_id UNIQUE (session_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_sessions_user_id ON user_sessions (user_id);
+CREATE INDEX IF NOT EXISTS idx_user_sessions_expires_at ON user_sessions (expires_at);

--- a/internal/domain/session.go
+++ b/internal/domain/session.go
@@ -1,0 +1,33 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// UserSession is a single login session belonging to a user. session_id is the
+// opaque value persisted in the End-User's cookie; multiple rows per user
+// represent separate browsers / devices.
+type UserSession struct {
+	ID           uuid.UUID
+	SessionID    string
+	UserID       uuid.UUID
+	UserAgent    string
+	IPAddress    string
+	ACR          string
+	AMR          []string
+	AuthTime     time.Time
+	LastActiveAt time.Time
+	ExpiresAt    time.Time
+	RevokedAt    *time.Time
+	CreatedAt    time.Time
+}
+
+// IsActive reports whether this session can still authenticate requests.
+func (s UserSession) IsActive(now time.Time) bool {
+	if s.RevokedAt != nil {
+		return false
+	}
+	return now.Before(s.ExpiresAt)
+}

--- a/internal/repository/helpers.go
+++ b/internal/repository/helpers.go
@@ -1,0 +1,22 @@
+package repository
+
+import (
+	"database/sql"
+
+	"github.com/google/uuid"
+)
+
+// nullString returns a sql.NullString that is invalid for the empty string,
+// matching how callers represent "absent" values throughout the repository.
+func nullString(s string) sql.NullString {
+	return sql.NullString{String: s, Valid: s != ""}
+}
+
+// nullUUID converts an optional uuid.UUID into the form sqlc-generated
+// parameter structs expect.
+func nullUUID(id *uuid.UUID) uuid.NullUUID { //nolint:unused // referenced by other repositories on feature branches
+	if id == nil {
+		return uuid.NullUUID{}
+	}
+	return uuid.NullUUID{UUID: *id, Valid: true}
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -36,6 +36,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.createTokenStmt, err = db.PrepareContext(ctx, createToken); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateToken: %w", err)
 	}
+	if q.createUserSessionStmt, err = db.PrepareContext(ctx, createUserSession); err != nil {
+		return nil, fmt.Errorf("error preparing query CreateUserSession: %w", err)
+	}
 	if q.deleteAllAuthorizationCodesStmt, err = db.PrepareContext(ctx, deleteAllAuthorizationCodes); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteAllAuthorizationCodes: %w", err)
 	}
@@ -96,11 +99,26 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.getTokenByRefreshTokenStmt, err = db.PrepareContext(ctx, getTokenByRefreshToken); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTokenByRefreshToken: %w", err)
 	}
+	if q.getUserSessionBySessionIDStmt, err = db.PrepareContext(ctx, getUserSessionBySessionID); err != nil {
+		return nil, fmt.Errorf("error preparing query GetUserSessionBySessionID: %w", err)
+	}
 	if q.listClientsStmt, err = db.PrepareContext(ctx, listClients); err != nil {
 		return nil, fmt.Errorf("error preparing query ListClients: %w", err)
 	}
+	if q.listUserSessionsByUserStmt, err = db.PrepareContext(ctx, listUserSessionsByUser); err != nil {
+		return nil, fmt.Errorf("error preparing query ListUserSessionsByUser: %w", err)
+	}
 	if q.markAuthorizationCodeUsedStmt, err = db.PrepareContext(ctx, markAuthorizationCodeUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkAuthorizationCodeUsed: %w", err)
+	}
+	if q.revokeAllUserSessionsExceptStmt, err = db.PrepareContext(ctx, revokeAllUserSessionsExcept); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeAllUserSessionsExcept: %w", err)
+	}
+	if q.revokeUserSessionStmt, err = db.PrepareContext(ctx, revokeUserSession); err != nil {
+		return nil, fmt.Errorf("error preparing query RevokeUserSession: %w", err)
+	}
+	if q.touchUserSessionStmt, err = db.PrepareContext(ctx, touchUserSession); err != nil {
+		return nil, fmt.Errorf("error preparing query TouchUserSession: %w", err)
 	}
 	if q.updateAuthorizationCodePKCEStmt, err = db.PrepareContext(ctx, updateAuthorizationCodePKCE); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAuthorizationCodePKCE: %w", err)
@@ -134,6 +152,11 @@ func (q *Queries) Close() error {
 	if q.createTokenStmt != nil {
 		if cerr := q.createTokenStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createTokenStmt: %w", cerr)
+		}
+	}
+	if q.createUserSessionStmt != nil {
+		if cerr := q.createUserSessionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing createUserSessionStmt: %w", cerr)
 		}
 	}
 	if q.deleteAllAuthorizationCodesStmt != nil {
@@ -236,14 +259,39 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing getTokenByRefreshTokenStmt: %w", cerr)
 		}
 	}
+	if q.getUserSessionBySessionIDStmt != nil {
+		if cerr := q.getUserSessionBySessionIDStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getUserSessionBySessionIDStmt: %w", cerr)
+		}
+	}
 	if q.listClientsStmt != nil {
 		if cerr := q.listClientsStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing listClientsStmt: %w", cerr)
 		}
 	}
+	if q.listUserSessionsByUserStmt != nil {
+		if cerr := q.listUserSessionsByUserStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing listUserSessionsByUserStmt: %w", cerr)
+		}
+	}
 	if q.markAuthorizationCodeUsedStmt != nil {
 		if cerr := q.markAuthorizationCodeUsedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markAuthorizationCodeUsedStmt: %w", cerr)
+		}
+	}
+	if q.revokeAllUserSessionsExceptStmt != nil {
+		if cerr := q.revokeAllUserSessionsExceptStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeAllUserSessionsExceptStmt: %w", cerr)
+		}
+	}
+	if q.revokeUserSessionStmt != nil {
+		if cerr := q.revokeUserSessionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing revokeUserSessionStmt: %w", cerr)
+		}
+	}
+	if q.touchUserSessionStmt != nil {
+		if cerr := q.touchUserSessionStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing touchUserSessionStmt: %w", cerr)
 		}
 	}
 	if q.updateAuthorizationCodePKCEStmt != nil {
@@ -304,6 +352,7 @@ type Queries struct {
 	createClientStmt                    *sql.Stmt
 	createOIDCSessionStmt               *sql.Stmt
 	createTokenStmt                     *sql.Stmt
+	createUserSessionStmt               *sql.Stmt
 	deleteAllAuthorizationCodesStmt     *sql.Stmt
 	deleteAllClientsStmt                *sql.Stmt
 	deleteAllOIDCSessionsStmt           *sql.Stmt
@@ -324,8 +373,13 @@ type Queries struct {
 	getTokenByAccessTokenStmt           *sql.Stmt
 	getTokenByIDStmt                    *sql.Stmt
 	getTokenByRefreshTokenStmt          *sql.Stmt
+	getUserSessionBySessionIDStmt       *sql.Stmt
 	listClientsStmt                     *sql.Stmt
+	listUserSessionsByUserStmt          *sql.Stmt
 	markAuthorizationCodeUsedStmt       *sql.Stmt
+	revokeAllUserSessionsExceptStmt     *sql.Stmt
+	revokeUserSessionStmt               *sql.Stmt
+	touchUserSessionStmt                *sql.Stmt
 	updateAuthorizationCodePKCEStmt     *sql.Stmt
 	updateClientStmt                    *sql.Stmt
 	updateClientSecretStmt              *sql.Stmt
@@ -339,6 +393,7 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		createClientStmt:                    q.createClientStmt,
 		createOIDCSessionStmt:               q.createOIDCSessionStmt,
 		createTokenStmt:                     q.createTokenStmt,
+		createUserSessionStmt:               q.createUserSessionStmt,
 		deleteAllAuthorizationCodesStmt:     q.deleteAllAuthorizationCodesStmt,
 		deleteAllClientsStmt:                q.deleteAllClientsStmt,
 		deleteAllOIDCSessionsStmt:           q.deleteAllOIDCSessionsStmt,
@@ -359,8 +414,13 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
 		getTokenByIDStmt:                    q.getTokenByIDStmt,
 		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
+		getUserSessionBySessionIDStmt:       q.getUserSessionBySessionIDStmt,
 		listClientsStmt:                     q.listClientsStmt,
+		listUserSessionsByUserStmt:          q.listUserSessionsByUserStmt,
 		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
+		revokeAllUserSessionsExceptStmt:     q.revokeAllUserSessionsExceptStmt,
+		revokeUserSessionStmt:               q.revokeUserSessionStmt,
+		touchUserSessionStmt:                q.touchUserSessionStmt,
 		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,
 		updateClientStmt:                    q.updateClientStmt,
 		updateClientSecretStmt:              q.updateClientSecretStmt,

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
 
 type AuthorizationCode struct {
@@ -57,4 +58,19 @@ type Token struct {
 	Scopes       string         `json:"scopes"`
 	ExpiresAt    time.Time      `json:"expires_at"`
 	CreatedAt    time.Time      `json:"created_at"`
+}
+
+type UserSession struct {
+	ID           uuid.UUID             `json:"id"`
+	SessionID    string                `json:"session_id"`
+	UserID       uuid.UUID             `json:"user_id"`
+	UserAgent    sql.NullString        `json:"user_agent"`
+	IpAddress    sql.NullString        `json:"ip_address"`
+	Acr          sql.NullString        `json:"acr"`
+	Amr          pqtype.NullRawMessage `json:"amr"`
+	AuthTime     time.Time             `json:"auth_time"`
+	LastActiveAt time.Time             `json:"last_active_at"`
+	ExpiresAt    time.Time             `json:"expires_at"`
+	RevokedAt    sql.NullTime          `json:"revoked_at"`
+	CreatedAt    time.Time             `json:"created_at"`
 }

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
 )
 
 const createAuthorizationCode = `-- name: CreateAuthorizationCode :exec
@@ -160,6 +161,49 @@ func (q *Queries) CreateToken(ctx context.Context, arg CreateTokenParams) error 
 		arg.AccessToken,
 		arg.RefreshToken,
 		arg.Scopes,
+		arg.ExpiresAt,
+	)
+	return err
+}
+
+const createUserSession = `-- name: CreateUserSession :exec
+
+INSERT INTO user_sessions (
+    id,
+    session_id,
+    user_id,
+    user_agent,
+    ip_address,
+    acr,
+    amr,
+    auth_time,
+    expires_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`
+
+type CreateUserSessionParams struct {
+	ID        uuid.UUID             `json:"id"`
+	SessionID string                `json:"session_id"`
+	UserID    uuid.UUID             `json:"user_id"`
+	UserAgent sql.NullString        `json:"user_agent"`
+	IpAddress sql.NullString        `json:"ip_address"`
+	Acr       sql.NullString        `json:"acr"`
+	Amr       pqtype.NullRawMessage `json:"amr"`
+	AuthTime  time.Time             `json:"auth_time"`
+	ExpiresAt time.Time             `json:"expires_at"`
+}
+
+// User session queries
+func (q *Queries) CreateUserSession(ctx context.Context, arg CreateUserSessionParams) error {
+	_, err := q.exec(ctx, q.createUserSessionStmt, createUserSession,
+		arg.ID,
+		arg.SessionID,
+		arg.UserID,
+		arg.UserAgent,
+		arg.IpAddress,
+		arg.Acr,
+		arg.Amr,
+		arg.AuthTime,
 		arg.ExpiresAt,
 	)
 	return err
@@ -421,6 +465,30 @@ func (q *Queries) GetTokenByRefreshToken(ctx context.Context, refreshToken sql.N
 	return i, err
 }
 
+const getUserSessionBySessionID = `-- name: GetUserSessionBySessionID :one
+SELECT id, session_id, user_id, user_agent, ip_address, acr, amr, auth_time, last_active_at, expires_at, revoked_at, created_at FROM user_sessions WHERE session_id = $1
+`
+
+func (q *Queries) GetUserSessionBySessionID(ctx context.Context, sessionID string) (UserSession, error) {
+	row := q.queryRow(ctx, q.getUserSessionBySessionIDStmt, getUserSessionBySessionID, sessionID)
+	var i UserSession
+	err := row.Scan(
+		&i.ID,
+		&i.SessionID,
+		&i.UserID,
+		&i.UserAgent,
+		&i.IpAddress,
+		&i.Acr,
+		&i.Amr,
+		&i.AuthTime,
+		&i.LastActiveAt,
+		&i.ExpiresAt,
+		&i.RevokedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
 const listClients = `-- name: ListClients :many
 SELECT client_id, client_secret_hash, name, client_type, redirect_uris, created_at, updated_at FROM clients
 `
@@ -456,12 +524,97 @@ func (q *Queries) ListClients(ctx context.Context) ([]Client, error) {
 	return items, nil
 }
 
+const listUserSessionsByUser = `-- name: ListUserSessionsByUser :many
+SELECT id, session_id, user_id, user_agent, ip_address, acr, amr, auth_time, last_active_at, expires_at, revoked_at, created_at FROM user_sessions
+WHERE user_id = $1 AND revoked_at IS NULL AND expires_at > CURRENT_TIMESTAMP
+ORDER BY last_active_at DESC
+`
+
+func (q *Queries) ListUserSessionsByUser(ctx context.Context, userID uuid.UUID) ([]UserSession, error) {
+	rows, err := q.query(ctx, q.listUserSessionsByUserStmt, listUserSessionsByUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserSession{}
+	for rows.Next() {
+		var i UserSession
+		if err := rows.Scan(
+			&i.ID,
+			&i.SessionID,
+			&i.UserID,
+			&i.UserAgent,
+			&i.IpAddress,
+			&i.Acr,
+			&i.Amr,
+			&i.AuthTime,
+			&i.LastActiveAt,
+			&i.ExpiresAt,
+			&i.RevokedAt,
+			&i.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const markAuthorizationCodeUsed = `-- name: MarkAuthorizationCodeUsed :exec
 UPDATE authorization_codes SET used = TRUE WHERE code = $1
 `
 
 func (q *Queries) MarkAuthorizationCodeUsed(ctx context.Context, code string) error {
 	_, err := q.exec(ctx, q.markAuthorizationCodeUsedStmt, markAuthorizationCodeUsed, code)
+	return err
+}
+
+const revokeAllUserSessionsExcept = `-- name: RevokeAllUserSessionsExcept :exec
+UPDATE user_sessions
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE user_id = $1 AND session_id <> $2 AND revoked_at IS NULL
+`
+
+type RevokeAllUserSessionsExceptParams struct {
+	UserID    uuid.UUID `json:"user_id"`
+	SessionID string    `json:"session_id"`
+}
+
+func (q *Queries) RevokeAllUserSessionsExcept(ctx context.Context, arg RevokeAllUserSessionsExceptParams) error {
+	_, err := q.exec(ctx, q.revokeAllUserSessionsExceptStmt, revokeAllUserSessionsExcept, arg.UserID, arg.SessionID)
+	return err
+}
+
+const revokeUserSession = `-- name: RevokeUserSession :exec
+UPDATE user_sessions
+SET revoked_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND user_id = $2
+`
+
+type RevokeUserSessionParams struct {
+	ID     uuid.UUID `json:"id"`
+	UserID uuid.UUID `json:"user_id"`
+}
+
+func (q *Queries) RevokeUserSession(ctx context.Context, arg RevokeUserSessionParams) error {
+	_, err := q.exec(ctx, q.revokeUserSessionStmt, revokeUserSession, arg.ID, arg.UserID)
+	return err
+}
+
+const touchUserSession = `-- name: TouchUserSession :exec
+UPDATE user_sessions
+SET last_active_at = CURRENT_TIMESTAMP
+WHERE session_id = $1
+`
+
+func (q *Queries) TouchUserSession(ctx context.Context, sessionID string) error {
+	_, err := q.exec(ctx, q.touchUserSessionStmt, touchUserSession, sessionID)
 	return err
 }
 

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -20,6 +20,8 @@ type Querier interface {
 	CreateOIDCSession(ctx context.Context, arg CreateOIDCSessionParams) error
 	// Token queries
 	CreateToken(ctx context.Context, arg CreateTokenParams) error
+	// User session queries
+	CreateUserSession(ctx context.Context, arg CreateUserSessionParams) error
 	DeleteAllAuthorizationCodes(ctx context.Context) error
 	DeleteAllClients(ctx context.Context) error
 	DeleteAllOIDCSessions(ctx context.Context) error
@@ -40,8 +42,13 @@ type Querier interface {
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
+	GetUserSessionBySessionID(ctx context.Context, sessionID string) (UserSession, error)
 	ListClients(ctx context.Context) ([]Client, error)
+	ListUserSessionsByUser(ctx context.Context, userID uuid.UUID) ([]UserSession, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
+	RevokeAllUserSessionsExcept(ctx context.Context, arg RevokeAllUserSessionsExceptParams) error
+	RevokeUserSession(ctx context.Context, arg RevokeUserSessionParams) error
+	TouchUserSession(ctx context.Context, sessionID string) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error
 	UpdateClient(ctx context.Context, arg UpdateClientParams) error
 	UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error

--- a/internal/repository/session.go
+++ b/internal/repository/session.go
@@ -1,0 +1,131 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/sqlc-dev/pqtype"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+var ErrUserSessionNotFound = errors.New("user session not found")
+
+type UserSessionRepository interface {
+	Create(ctx context.Context, session domain.UserSession) error
+	GetBySessionID(ctx context.Context, sessionID string) (domain.UserSession, error)
+	ListByUser(ctx context.Context, userID uuid.UUID) ([]domain.UserSession, error)
+	Touch(ctx context.Context, sessionID string) error
+	Revoke(ctx context.Context, id, userID uuid.UUID) error
+	RevokeAllExcept(ctx context.Context, userID uuid.UUID, keepSessionID string) error
+}
+
+type userSessionRepository struct {
+	queries *oidc.Queries
+}
+
+func NewUserSessionRepository(queries *oidc.Queries) UserSessionRepository {
+	return &userSessionRepository{queries: queries}
+}
+
+func (r *userSessionRepository) Create(ctx context.Context, s domain.UserSession) error {
+	id := s.ID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
+	amr := pqtype.NullRawMessage{}
+	if len(s.AMR) > 0 {
+		raw, err := json.Marshal(s.AMR)
+		if err != nil {
+			return err
+		}
+		amr = pqtype.NullRawMessage{RawMessage: raw, Valid: true}
+	}
+	return r.queries.CreateUserSession(ctx, oidc.CreateUserSessionParams{
+		ID:        id,
+		SessionID: s.SessionID,
+		UserID:    s.UserID,
+		UserAgent: nullString(s.UserAgent),
+		IpAddress: nullString(s.IPAddress),
+		Acr:       nullString(s.ACR),
+		Amr:       amr,
+		AuthTime:  s.AuthTime,
+		ExpiresAt: s.ExpiresAt,
+	})
+}
+
+func (r *userSessionRepository) GetBySessionID(ctx context.Context, sessionID string) (domain.UserSession, error) {
+	row, err := r.queries.GetUserSessionBySessionID(ctx, sessionID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.UserSession{}, ErrUserSessionNotFound
+		}
+		return domain.UserSession{}, err
+	}
+	return toDomainUserSession(row)
+}
+
+func (r *userSessionRepository) ListByUser(ctx context.Context, userID uuid.UUID) ([]domain.UserSession, error) {
+	rows, err := r.queries.ListUserSessionsByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]domain.UserSession, 0, len(rows))
+	for _, row := range rows {
+		s, err := toDomainUserSession(row)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (r *userSessionRepository) Touch(ctx context.Context, sessionID string) error {
+	return r.queries.TouchUserSession(ctx, sessionID)
+}
+
+func (r *userSessionRepository) Revoke(ctx context.Context, id, userID uuid.UUID) error {
+	return r.queries.RevokeUserSession(ctx, oidc.RevokeUserSessionParams{
+		ID:     id,
+		UserID: userID,
+	})
+}
+
+func (r *userSessionRepository) RevokeAllExcept(ctx context.Context, userID uuid.UUID, keepSessionID string) error {
+	return r.queries.RevokeAllUserSessionsExcept(ctx, oidc.RevokeAllUserSessionsExceptParams{
+		UserID:    userID,
+		SessionID: keepSessionID,
+	})
+}
+
+func toDomainUserSession(row oidc.UserSession) (domain.UserSession, error) {
+	var amr []string
+	if row.Amr.Valid {
+		if err := json.Unmarshal(row.Amr.RawMessage, &amr); err != nil {
+			return domain.UserSession{}, err
+		}
+	}
+	s := domain.UserSession{
+		ID:           row.ID,
+		SessionID:    row.SessionID,
+		UserID:       row.UserID,
+		UserAgent:    row.UserAgent.String,
+		IPAddress:    row.IpAddress.String,
+		ACR:          row.Acr.String,
+		AMR:          amr,
+		AuthTime:     row.AuthTime,
+		LastActiveAt: row.LastActiveAt,
+		ExpiresAt:    row.ExpiresAt,
+		CreatedAt:    row.CreatedAt,
+	}
+	if row.RevokedAt.Valid {
+		t := row.RevokedAt.Time
+		s.RevokedAt = &t
+	}
+	return s, nil
+}

--- a/internal/router/v1/auth.go
+++ b/internal/router/v1/auth.go
@@ -3,13 +3,17 @@ package v1
 import (
 	"errors"
 	"html"
+	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v5"
 
+	"github.com/traPtitech/portal-oidc/internal/domain"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -89,7 +93,39 @@ func (h *Handler) PostLogin(ctx *echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save session")
 	}
 
+	h.persistUserSession(ctx, session.ID, userID)
+
 	return ctx.Redirect(http.StatusFound, sanitizeReturnURL(returnURL))
+}
+
+// persistUserSession mirrors the cookie session into the user_sessions table
+// so /auth/sessions can list or revoke it. Best-effort: a DB failure here is
+// logged but does not fail the login because the cookie is the active source
+// of truth until a follow-up PR flips the dependency.
+func (h *Handler) persistUserSession(ctx *echo.Context, cookieID, userIDStr string) {
+	if h.userSessions == nil || cookieID == "" {
+		return
+	}
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return
+	}
+	expires := time.Now().Add(time.Duration(h.sessions.Options.MaxAge) * time.Second)
+	host, _, splitErr := net.SplitHostPort(ctx.Request().RemoteAddr)
+	if splitErr != nil {
+		host = ctx.Request().RemoteAddr
+	}
+	row := domain.UserSession{
+		SessionID: cookieID,
+		UserID:    userID,
+		UserAgent: ctx.Request().Header.Get("User-Agent"),
+		IPAddress: host,
+		AuthTime:  time.Now(),
+		ExpiresAt: expires,
+	}
+	if err := h.userSessions.Create(ctx.Request().Context(), row); err != nil {
+		log.Printf("auth: failed to persist user_session: %v", err)
+	}
 }
 
 func (h *Handler) authenticateTestUser(username, password string) (string, error) {

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -179,7 +179,9 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
+	userSessionRepo := repository.NewUserSessionRepository(queries)
+
+	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, userSessionRepo, OAuthConfig{
 		Issuer:      "http://localhost:8080",
 		Environment: "development",
 		TestUserID:  "00000000-0000-0000-0000-000000000000",

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -16,6 +17,7 @@ type Handler struct {
 	oauthUseCase  usecase.OAuthUseCase
 	oauth2        fosite.OAuth2Provider
 	userUseCase   usecase.UserUseCase
+	userSessions  repository.UserSessionRepository
 	sessions      *sessions.CookieStore
 	config        OAuthConfig
 }
@@ -33,6 +35,7 @@ func NewHandler(
 	oauthUseCase usecase.OAuthUseCase,
 	oauth2 fosite.OAuth2Provider,
 	userUseCase usecase.UserUseCase,
+	userSessions repository.UserSessionRepository,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -49,6 +52,7 @@ func NewHandler(
 		oauthUseCase:  oauthUseCase,
 		oauth2:        oauth2,
 		userUseCase:   userUseCase,
+		userSessions:  userSessions,
 		sessions:      store,
 		config:        config,
 	}

--- a/internal/router/v1/sessions.go
+++ b/internal/router/v1/sessions.go
@@ -1,0 +1,149 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository"
+)
+
+// sessionView is the JSON shape returned by the /auth/session endpoints.
+// It deliberately omits the raw cookie session_id because callers should not
+// be able to read another browser's cookie value out of this API.
+type sessionView struct {
+	ID           uuid.UUID `json:"id"`
+	UserAgent    string    `json:"user_agent,omitempty"`
+	IPAddress    string    `json:"ip_address,omitempty"`
+	ACR          string    `json:"acr,omitempty"`
+	AMR          []string  `json:"amr,omitempty"`
+	AuthTime     int64     `json:"auth_time"`
+	LastActiveAt int64     `json:"last_active_at"`
+	ExpiresAt    int64     `json:"expires_at"`
+	Current      bool      `json:"current"`
+}
+
+// GetSession returns metadata about the caller's currently-active session.
+//
+// Refs:
+//   - traPortal v2 仕様 §セッション (GET /auth/session)
+func (h *Handler) GetSession(ctx *echo.Context) error {
+	cookieID, info, ok := h.currentSession(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	if h.userSessions == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "session storage not configured")
+	}
+	current, err := h.userSessions.GetBySessionID(ctx.Request().Context(), cookieID)
+	if err != nil {
+		if errors.Is(err, repository.ErrUserSessionNotFound) {
+			return echo.NewHTTPError(http.StatusUnauthorized, "session not tracked")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to load session")
+	}
+	_ = info // info is only used to confirm the cookie was decryptable
+	return ctx.JSON(http.StatusOK, toSessionView(current, true))
+}
+
+// ListSessions returns every active session belonging to the caller, with the
+// caller's own session marked Current=true so the UI can render a hint.
+func (h *Handler) ListSessions(ctx *echo.Context) error {
+	cookieID, info, ok := h.currentSession(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	if h.userSessions == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "session storage not configured")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+
+	rows, err := h.userSessions.ListByUser(ctx.Request().Context(), userID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to list sessions")
+	}
+	out := make([]sessionView, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, toSessionView(row, row.SessionID == cookieID))
+	}
+	return ctx.JSON(http.StatusOK, out)
+}
+
+// RevokeSession terminates the session identified by the path parameter,
+// rejecting attempts to revoke sessions that belong to a different user.
+func (h *Handler) RevokeSession(ctx *echo.Context) error {
+	_, info, ok := h.currentSession(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	if h.userSessions == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "session storage not configured")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	id, err := uuid.Parse(ctx.Param("sessionId"))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid sessionId")
+	}
+	if err := h.userSessions.Revoke(ctx.Request().Context(), id, userID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to revoke session")
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// RevokeAllOtherSessions terminates every active session for the caller
+// except the one currently in use. Useful for "sign out everywhere else".
+func (h *Handler) RevokeAllOtherSessions(ctx *echo.Context) error {
+	cookieID, info, ok := h.currentSession(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	if h.userSessions == nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "session storage not configured")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	if err := h.userSessions.RevokeAllExcept(ctx.Request().Context(), userID, cookieID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to revoke sessions")
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// currentSession returns the cookie session ID and authInfo for the caller.
+// The cookie session is the source of truth for "who is logged in" today;
+// the user_sessions table is a parallel record keyed by the same cookie value.
+func (h *Handler) currentSession(ctx *echo.Context) (string, authInfo, bool) {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return "", authInfo{}, false
+	}
+	sess, err := h.sessions.Get(ctx.Request(), sessionName)
+	if err != nil {
+		return "", authInfo{}, false
+	}
+	return sess.ID, info, true
+}
+
+func toSessionView(s domain.UserSession, current bool) sessionView {
+	return sessionView{
+		ID:           s.ID,
+		UserAgent:    s.UserAgent,
+		IPAddress:    s.IPAddress,
+		ACR:          s.ACR,
+		AMR:          s.AMR,
+		AuthTime:     s.AuthTime.Unix(),
+		LastActiveAt: s.LastActiveAt.Unix(),
+		ExpiresAt:    s.ExpiresAt.Unix(),
+		Current:      current,
+	}
+}


### PR DESCRIPTION
## 概要

End-User のログインセッションを永続化する \`user_sessions\` テーブルと、ユーザー/管理画面から閲覧・失効可能にする \`/auth/sessions\` API を追加。

## 背景

仕様の \`sessions\` テーブル + Session API:
| メソッド | パス | 説明 |
|---|---|---|
| GET | \`/auth/session\` | 現在のセッション情報 |
| GET | \`/auth/sessions\` | 自分のセッション一覧 |
| DELETE | \`/auth/sessions/{sessionId}\` | セッション削除 |
| DELETE | \`/auth/sessions\` | 全セッション削除 (現在除く) |

## 変更

### スキーマ・クエリ
- \`db/schema.sql\`: \`user_sessions\` テーブル + UNIQUE(session_id), INDEX(user_id, expires_at)
- \`db/query/oidc.sql\`: Create / GetBySessionID / ListByUser / Touch / Revoke / RevokeAllExcept
- \`internal/repository/oidc/*\`: sqlc 自動生成
- \`internal/repository/helpers.go\` (新規): \`nullString\` / \`nullUUID\` を共有ヘルパーへ

### Domain / Repository
- \`internal/domain/session.go\`: \`UserSession\` + \`IsActive\` ヘルパー
- \`internal/repository/session.go\`: \`UserSessionRepository\` 実装

### Handler
- \`internal/router/v1/sessions.go\` (新規):
  - \`GetSession\`, \`ListSessions\`, \`RevokeSession\`, \`RevokeAllOtherSessions\`
  - \`Current\` flag で「自分のいまのセッション」を識別
  - 他ユーザーのセッションは revoke 不可 (\`(id, user_id)\` の AND)
- \`internal/router/v1/auth.go\`: \`PostLogin\` 成功時に \`persistUserSession\` を呼ぶ。失敗は log のみ (cookie が source of truth なので login 失敗にはしない)
- \`internal/router/v1/handler.go\`: \`userSessions\` フィールド追加
- \`cmd/serve.go\`: 注入 + ルート登録
- \`internal/router/v1/client_test.go\`: テストハンドラに repo 注入

### Storage flip 戦略
本 PR では cookie session が source of truth のまま。\`user_sessions\` は **並列レコード** として作成。
このため \`DELETE /auth/sessions/{id}\` を呼んでも該当 cookie で次のリクエストは依然通る (cookie 期限まで) が、API 自体はそのままユーザに公開して問題なし。

**follow-up PR**: cookie session_id に対して \`user_sessions\` の active row をリクエスト毎にチェックする middleware を追加し、即時失効に切り替え。

## RFC / 仕様根拠

| 項目 | 仕様 |
|---|---|
| sessions テーブル + Session API | traPortal v2 仕様 §セッション |
| acr / amr claim values | [RFC 8176 §2](https://datatracker.ietf.org/doc/html/rfc8176) |

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` 0 issues (確認済み)
- [ ] 手動: 2 ブラウザでログイン → \`GET /auth/sessions\` で 2 件返ること
- [ ] 手動: \`DELETE /auth/sessions\` で 1 件 (current) のみ残ること