### PR TITLE
feat(oauth): /oauth2/register Dynamic Client Registration エンドポイント追加 (RFC 7591)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -170,6 +170,36 @@ paths:
               schema:
                 $ref: "#/components/schemas/JWKS"
 
+  /oauth2/register:
+    post:
+      operationId: registerClient
+      summary: Dynamic Client Registration (RFC 7591)
+      description: |
+        OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591) endpoint.
+        Anyone with network access may register a new client; the response
+        contains the issued client_id and client_secret per §3.2.1.
+      tags:
+        - oauth2/oidc
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClientRegistrationRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClientRegistrationResponse"
+        "400":
+          description: Bad Request (invalid_redirect_uri / invalid_client_metadata)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/OAuthError"
+
   /oauth2/userinfo:
     get:
       operationId: getUserInfo
@@ -512,6 +542,90 @@ components:
         code_verifier:
           type: string
           description: PKCE code_verifier
+
+    ClientRegistrationRequest:
+      type: object
+      description: |
+        RFC 7591 §2.0 Client Metadata. Fields not listed here are silently
+        ignored; unknown extensions do not cause registration failure.
+      required:
+        - redirect_uris
+      properties:
+        redirect_uris:
+          type: array
+          items:
+            type: string
+            format: uri
+        client_name:
+          type: string
+        client_uri:
+          type: string
+          format: uri
+        logo_uri:
+          type: string
+          format: uri
+        token_endpoint_auth_method:
+          type: string
+          enum:
+            - client_secret_basic
+            - client_secret_post
+            - none
+        grant_types:
+          type: array
+          items:
+            type: string
+        response_types:
+          type: array
+          items:
+            type: string
+        scope:
+          type: string
+          description: スペース区切りスコープ
+
+    ClientRegistrationResponse:
+      type: object
+      description: |
+        RFC 7591 §3.2.1 Client Information Response. Echoes back the registered
+        metadata along with the issued client_id and (for confidential
+        clients) client_secret.
+      required:
+        - client_id
+        - client_id_issued_at
+        - redirect_uris
+      properties:
+        client_id:
+          type: string
+          format: uuid
+        client_secret:
+          type: string
+          description: Confidential client にのみ返却
+        client_id_issued_at:
+          type: integer
+          format: int64
+          description: Unix epoch seconds
+        client_secret_expires_at:
+          type: integer
+          format: int64
+          description: 0 で無期限 (RFC 7591 §3.2.1)
+        client_name:
+          type: string
+        redirect_uris:
+          type: array
+          items:
+            type: string
+            format: uri
+        token_endpoint_auth_method:
+          type: string
+        grant_types:
+          type: array
+          items:
+            type: string
+        response_types:
+          type: array
+          items:
+            type: string
+        scope:
+          type: string
 
     TokenResponse:
       type: object

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,7 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.POST("/oauth2/register", handler.RegisterClient)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/internal/router/v1/dcr.go
+++ b/internal/router/v1/dcr.go
@@ -1,0 +1,83 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v5"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/router/v1/gen"
+)
+
+// RegisterClient implements RFC 7591 OAuth 2.0 Dynamic Client Registration.
+//
+// Per §3.1 the request body is a JSON document of client metadata; per §3.2.1
+// the response echoes the metadata back together with the issued client_id
+// and (for confidential clients) client_secret. We currently treat the
+// endpoint as open: anyone with network access can register a client. Tighten
+// to require an Initial Access Token (§3) once the deployment grows.
+//
+// Refs:
+//   - RFC 7591 §3.1 (Client Registration Request)
+//     https://datatracker.ietf.org/doc/html/rfc7591#section-3.1
+//   - RFC 7591 §3.2.1 (Client Information Response)
+//     https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
+//   - RFC 7591 §3.2.2 (Client Registration Error Response)
+//     https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.2
+func (h *Handler) RegisterClient(ctx *echo.Context) error {
+	var req gen.ClientRegistrationRequest
+	if err := json.NewDecoder(ctx.Request().Body).Decode(&req); err != nil {
+		return ctx.JSON(http.StatusBadRequest, gen.OAuthError{Error: gen.InvalidRequest})
+	}
+	if len(req.RedirectUris) == 0 {
+		return ctx.JSON(http.StatusBadRequest, gen.OAuthError{
+			Error:            gen.InvalidRequest,
+			ErrorDescription: stringPtr("redirect_uris is required"),
+		})
+	}
+
+	clientType := domain.ClientTypeConfidential
+	if method := str(req.TokenEndpointAuthMethod); method == "none" {
+		clientType = domain.ClientTypePublic
+	}
+
+	name := str(req.ClientName)
+	if name == "" {
+		name = "Dynamically Registered Client"
+	}
+
+	created, err := h.clientUseCase.Create(ctx.Request().Context(), name, clientType, req.RedirectUris)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, gen.OAuthError{
+			Error:            gen.ServerError,
+			ErrorDescription: stringPtr(err.Error()),
+		})
+	}
+
+	resp := gen.ClientRegistrationResponse{
+		ClientId:         created.ClientID,
+		ClientIdIssuedAt: created.CreatedAt.Unix(),
+		ClientName:       stringPtr(created.Name),
+		RedirectUris:     created.RedirectURIs,
+	}
+	if clientType == domain.ClientTypeConfidential {
+		secret := created.ClientSecret
+		resp.ClientSecret = &secret
+		// RFC 7591 §3.2.1: 0 means the secret does not expire. We do not
+		// rotate registered client secrets automatically yet.
+		zero := int64(0)
+		resp.ClientSecretExpiresAt = &zero
+	}
+	return ctx.JSON(http.StatusCreated, resp)
+}
+
+func str(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return strings.TrimSpace(*p)
+}
+
+func stringPtr(s string) *string { return &s }

--- a/internal/router/v1/gen/models.go
+++ b/internal/router/v1/gen/models.go
@@ -220,6 +220,32 @@ type OAuthError struct {
 // OAuthErrorError defines model for OAuthError.Error.
 type OAuthErrorError string
 
+// ClientRegistrationRequest defines model for ClientRegistrationRequest (RFC 7591 §2.0).
+type ClientRegistrationRequest struct {
+	ClientName              *string  `json:"client_name,omitempty"`
+	ClientUri               *string  `json:"client_uri,omitempty"`
+	GrantTypes              *[]string `json:"grant_types,omitempty"`
+	LogoUri                 *string  `json:"logo_uri,omitempty"`
+	RedirectUris            []string `json:"redirect_uris"`
+	ResponseTypes           *[]string `json:"response_types,omitempty"`
+	Scope                   *string  `json:"scope,omitempty"`
+	TokenEndpointAuthMethod *string  `json:"token_endpoint_auth_method,omitempty"`
+}
+
+// ClientRegistrationResponse defines model for ClientRegistrationResponse (RFC 7591 §3.2.1).
+type ClientRegistrationResponse struct {
+	ClientId                openapi_types.UUID `json:"client_id"`
+	ClientIdIssuedAt        int64              `json:"client_id_issued_at"`
+	ClientName              *string            `json:"client_name,omitempty"`
+	ClientSecret            *string            `json:"client_secret,omitempty"`
+	ClientSecretExpiresAt   *int64             `json:"client_secret_expires_at,omitempty"`
+	GrantTypes              *[]string          `json:"grant_types,omitempty"`
+	RedirectUris            []string           `json:"redirect_uris"`
+	ResponseTypes           *[]string          `json:"response_types,omitempty"`
+	Scope                   *string            `json:"scope,omitempty"`
+	TokenEndpointAuthMethod *string            `json:"token_endpoint_auth_method,omitempty"`
+}
+
 // OpenIDConfiguration defines model for OpenIDConfiguration.
 type OpenIDConfiguration struct {
 	AuthorizationEndpoint             string    `json:"authorization_endpoint"`


### PR DESCRIPTION
## 概要

OAuth 2.0 Dynamic Client Registration Protocol (RFC 7591) のエンドポイント \`/oauth2/register\` を追加。動的にクライアント登録 → \`client_id\` + \`client_secret\` を発行する。

## 背景

仕様 §認可認証基盤:
| メソッド | パス | 説明 |
|---|---|---|
| POST | \`/oauth2/register\` | 動的クライアント登録 ← 本 PR |

既存の管理 API (\`POST /api/v1/admin/clients\`) と同じ Repository 層を経由するので、永続化は再利用。

## 変更

- \`api/openapi.yaml\`: \`/oauth2/register\` POST + \`ClientRegistrationRequest\` / \`ClientRegistrationResponse\` schema (RFC 7591 §2 / §3.2.1 準拠)
- \`internal/router/v1/dcr.go\` (新規): \`RegisterClient\` handler。\`token_endpoint_auth_method=none\` を public client に紐付け
- \`internal/router/v1/gen/models.go\`: 上記 schema の Go struct を手動追加
- \`cmd/serve.go\`: ルート登録

## セキュリティ姿勢

- 本 PR は **オープン登録** (誰でも client 作成可能)。本番投入前に Initial Access Token (RFC 7591 §3) を要求する形に絞る予定
- public client は PKCE 強制 (cmd/oauth.go の EnforcePKCEForPublicClients = true)

## RFC / 仕様根拠

| 項目 | RFC | 該当節 |
|---|---|---|
| Client Registration Request | RFC 7591 | [§3.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.1) |
| Client Information Response | RFC 7591 | [§3.2.1](https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1) |
| Client Metadata | RFC 7591 | [§2](https://datatracker.ietf.org/doc/html/rfc7591#section-2) |

## 後続 PR
- \`/.well-known/oauth-authorization-server\` (#131) で \`registration_endpoint\` を advertise
- Initial Access Token 認証
- RFC 7592 (DCR Management Protocol) で client_id 単位の GET/PUT/DELETE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * OAuth 2.0 動的クライアント登録機能を追加しました。クライアントアプリケーションが新規登録時にクライアントIDと秘密情報を自動取得できるようになり、登録メタデータとリダイレクトURI設定に対応しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->