### PR TITLE
feat(oauth): Device Authorization Grant 実装 (RFC 8628)

### DIFF
--- a/cmd/oauth.go
+++ b/cmd/oauth.go
@@ -15,8 +15,21 @@ import (
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
+	"github.com/ory/fosite/handler/oauth2"
 	"github.com/ory/fosite/token/jwt"
 )
+
+// newTokenStrategy returns an HMAC strategy initialised with the same secret
+// fosite uses for the standard grants. The Device Authorization Grant
+// (RFC 8628) handler uses it to mint access and refresh tokens that the rest
+// of the system (introspection, /userinfo) can validate verbatim.
+func newTokenStrategy(config OAuthProviderConfig) *oauth2.HMACSHAStrategy {
+	return compose.NewOAuth2HMACStrategy(&fosite.Config{
+		AccessTokenLifespan:  config.AccessTokenLifespan,
+		RefreshTokenLifespan: config.RefreshTokenLifespan,
+		GlobalSecret:         config.Secret,
+	})
+}
 
 type OAuthProviderConfig struct {
 	Issuer               string

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -43,14 +43,16 @@ func newServer(cfg Config) (http.Handler, error) {
 		repository.NewOIDCSessionRepository(queries),
 	)
 	defaults := defaultOAuthProviderConfig()
-	oauth2Provider := newOAuthProvider(oauthStorage, OAuthProviderConfig{
+	providerCfg := OAuthProviderConfig{
 		Issuer:               cfg.Host,
 		AccessTokenLifespan:  defaults.AccessTokenLifespan,
 		RefreshTokenLifespan: defaults.RefreshTokenLifespan,
 		AuthCodeLifespan:     defaults.AuthCodeLifespan,
 		IDTokenLifespan:      defaults.IDTokenLifespan,
 		Secret:               []byte(cfg.OAuth.Secret),
-	}, privateKey)
+	}
+	oauth2Provider := newOAuthProvider(oauthStorage, providerCfg, privateKey)
+	tokenStrategy := newTokenStrategy(providerCfg)
 
 	var userUseCase usecase.UserUseCase
 	if cfg.Environment == "production" {
@@ -60,11 +62,16 @@ func newServer(cfg Config) (http.Handler, error) {
 		}
 		userUseCase = usecase.NewUserUseCase(repository.NewUserRepository(portalQueries))
 	}
+	tokenRepo := repository.NewTokenRepository(queries)
+	deviceAuthRepo := repository.NewDeviceAuthorizationRepository(queries)
 	handler := v1.NewHandler(
 		usecase.NewClientUseCase(clientRepo),
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
+		tokenStrategy,
 		userUseCase,
+		tokenRepo,
+		deviceAuthRepo,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),
@@ -82,6 +89,9 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.POST("/oauth2/device/code", handler.DeviceAuthorize)
+	e.GET("/oauth2/device", handler.GetDeviceVerification)
+	e.POST("/oauth2/device", handler.PostDeviceVerification)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,42 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- Device authorization queries (RFC 8628)
+
+-- name: CreateDeviceAuthorization :exec
+INSERT INTO device_authorizations (
+    id,
+    device_code,
+    user_code,
+    client_id,
+    scopes,
+    expires_at,
+    poll_interval
+) VALUES ($1, $2, $3, $4, $5, $6, $7);
+
+-- name: GetDeviceAuthorizationByDeviceCode :one
+SELECT * FROM device_authorizations WHERE device_code = $1;
+
+-- name: GetDeviceAuthorizationByUserCode :one
+SELECT * FROM device_authorizations WHERE user_code = $1;
+
+-- name: ApproveDeviceAuthorization :exec
+UPDATE device_authorizations
+SET status = 'authorized', user_id = $2, authorized_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND status = 'pending';
+
+-- name: DenyDeviceAuthorization :exec
+UPDATE device_authorizations
+SET status = 'denied'
+WHERE id = $1 AND status = 'pending';
+
+-- name: TouchDeviceAuthorization :exec
+UPDATE device_authorizations
+SET last_polled_at = CURRENT_TIMESTAMP
+WHERE device_code = $1;
+
+-- name: ExpireDeviceAuthorizations :exec
+UPDATE device_authorizations
+SET status = 'expired'
+WHERE status = 'pending' AND expires_at < CURRENT_TIMESTAMP;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,31 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §device_authorizations
+-- Persistent state for the OAuth 2.0 Device Authorization Grant (RFC 8628).
+-- A row is created when a device requests user authentication; its status
+-- transitions pending → authorized | denied | expired. user_id stays NULL
+-- until the human user completes the verification ceremony.
+CREATE TABLE IF NOT EXISTS device_authorizations (
+  id UUID NOT NULL,
+  device_code TEXT NOT NULL,
+  user_code TEXT NOT NULL,
+  client_id UUID NOT NULL,
+  user_id UUID NULL,
+  scopes TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  expires_at TIMESTAMPTZ NOT NULL,
+  poll_interval INT NOT NULL DEFAULT 5,
+  last_polled_at TIMESTAMPTZ NULL,
+  authorized_at TIMESTAMPTZ NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT idx_device_authorizations_device_code UNIQUE (device_code),
+  CONSTRAINT idx_device_authorizations_user_code UNIQUE (user_code),
+  CONSTRAINT chk_device_authorizations_status CHECK (status IN ('pending', 'authorized', 'denied', 'expired')),
+  CONSTRAINT fk_device_authorizations_client FOREIGN KEY (client_id) REFERENCES clients (client_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_authorizations_status ON device_authorizations (status);
+CREATE INDEX IF NOT EXISTS idx_device_authorizations_expires_at ON device_authorizations (expires_at);

--- a/internal/domain/device.go
+++ b/internal/domain/device.go
@@ -1,0 +1,44 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// DeviceAuthorizationStatus represents the lifecycle of a Device
+// Authorization Grant (RFC 8628). A row begins as Pending; the user either
+// approves it (Authorized) or denies it (Denied), and a sweep marks any
+// row whose expires_at has passed as Expired.
+type DeviceAuthorizationStatus string
+
+const (
+	DeviceAuthorizationStatusPending    DeviceAuthorizationStatus = "pending"
+	DeviceAuthorizationStatusAuthorized DeviceAuthorizationStatus = "authorized"
+	DeviceAuthorizationStatusDenied     DeviceAuthorizationStatus = "denied"
+	DeviceAuthorizationStatusExpired    DeviceAuthorizationStatus = "expired"
+)
+
+// DeviceAuthorization is the server-side state of an in-flight Device
+// Authorization Grant. DeviceCode is shared with the device polling for
+// tokens; UserCode is shown to the human entering it on a browser.
+type DeviceAuthorization struct {
+	ID           uuid.UUID
+	DeviceCode   string
+	UserCode     string
+	ClientID     uuid.UUID
+	UserID       *uuid.UUID
+	Scopes       []string
+	Status       DeviceAuthorizationStatus
+	ExpiresAt    time.Time
+	PollInterval int
+	LastPolledAt *time.Time
+	AuthorizedAt *time.Time
+	CreatedAt    time.Time
+}
+
+// IsExpired reports whether the authorization has passed its TTL irrespective
+// of stored Status (Status may not have been swept yet).
+func (d DeviceAuthorization) IsExpired(now time.Time) bool {
+	return !now.Before(d.ExpiresAt)
+}

--- a/internal/repository/device.go
+++ b/internal/repository/device.go
@@ -1,0 +1,116 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+var ErrDeviceAuthorizationNotFound = errors.New("device authorization not found")
+
+type DeviceAuthorizationRepository interface {
+	Create(ctx context.Context, d domain.DeviceAuthorization) error
+	GetByDeviceCode(ctx context.Context, deviceCode string) (domain.DeviceAuthorization, error)
+	GetByUserCode(ctx context.Context, userCode string) (domain.DeviceAuthorization, error)
+	Approve(ctx context.Context, id, userID uuid.UUID) error
+	Deny(ctx context.Context, id uuid.UUID) error
+	Touch(ctx context.Context, deviceCode string) error
+	ExpirePending(ctx context.Context) error
+}
+
+type deviceAuthorizationRepository struct {
+	queries *oidc.Queries
+}
+
+func NewDeviceAuthorizationRepository(queries *oidc.Queries) DeviceAuthorizationRepository {
+	return &deviceAuthorizationRepository{queries: queries}
+}
+
+func (r *deviceAuthorizationRepository) Create(ctx context.Context, d domain.DeviceAuthorization) error {
+	id := d.ID
+	if id == uuid.Nil {
+		id = uuid.New()
+	}
+	return r.queries.CreateDeviceAuthorization(ctx, oidc.CreateDeviceAuthorizationParams{
+		ID:         id,
+		DeviceCode: d.DeviceCode,
+		UserCode:   d.UserCode,
+		ClientID:   d.ClientID,
+		Scopes:     strings.Join(d.Scopes, " "),
+		ExpiresAt:  d.ExpiresAt,
+		// #nosec G115 -- poll intervals are seconds and fit in int32
+		PollInterval: int32(d.PollInterval),
+	})
+}
+
+func (r *deviceAuthorizationRepository) GetByDeviceCode(ctx context.Context, deviceCode string) (domain.DeviceAuthorization, error) {
+	row, err := r.queries.GetDeviceAuthorizationByDeviceCode(ctx, deviceCode)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.DeviceAuthorization{}, ErrDeviceAuthorizationNotFound
+		}
+		return domain.DeviceAuthorization{}, err
+	}
+	return toDomainDeviceAuthorization(row), nil
+}
+
+func (r *deviceAuthorizationRepository) GetByUserCode(ctx context.Context, userCode string) (domain.DeviceAuthorization, error) {
+	row, err := r.queries.GetDeviceAuthorizationByUserCode(ctx, userCode)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.DeviceAuthorization{}, ErrDeviceAuthorizationNotFound
+		}
+		return domain.DeviceAuthorization{}, err
+	}
+	return toDomainDeviceAuthorization(row), nil
+}
+
+func (r *deviceAuthorizationRepository) Approve(ctx context.Context, id, userID uuid.UUID) error {
+	return r.queries.ApproveDeviceAuthorization(ctx, oidc.ApproveDeviceAuthorizationParams{
+		ID:     id,
+		UserID: uuid.NullUUID{UUID: userID, Valid: true},
+	})
+}
+
+func (r *deviceAuthorizationRepository) Deny(ctx context.Context, id uuid.UUID) error {
+	return r.queries.DenyDeviceAuthorization(ctx, id)
+}
+
+func (r *deviceAuthorizationRepository) Touch(ctx context.Context, deviceCode string) error {
+	return r.queries.TouchDeviceAuthorization(ctx, deviceCode)
+}
+
+func (r *deviceAuthorizationRepository) ExpirePending(ctx context.Context) error {
+	return r.queries.ExpireDeviceAuthorizations(ctx)
+}
+
+func toDomainDeviceAuthorization(row oidc.DeviceAuthorization) domain.DeviceAuthorization {
+	d := domain.DeviceAuthorization{
+		ID:           row.ID,
+		DeviceCode:   row.DeviceCode,
+		UserCode:     row.UserCode,
+		ClientID:     row.ClientID,
+		Scopes:       splitScopes(row.Scopes),
+		Status:       domain.DeviceAuthorizationStatus(row.Status),
+		ExpiresAt:    row.ExpiresAt,
+		PollInterval: int(row.PollInterval),
+		CreatedAt:    row.CreatedAt,
+	}
+	if row.UserID.Valid {
+		id := row.UserID.UUID
+		d.UserID = &id
+	}
+	if row.LastPolledAt.Valid {
+		d.LastPolledAt = &row.LastPolledAt.Time
+	}
+	if row.AuthorizedAt.Valid {
+		d.AuthorizedAt = &row.AuthorizedAt.Time
+	}
+	return d
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -24,11 +24,17 @@ func New(db DBTX) *Queries {
 func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	q := Queries{db: db}
 	var err error
+	if q.approveDeviceAuthorizationStmt, err = db.PrepareContext(ctx, approveDeviceAuthorization); err != nil {
+		return nil, fmt.Errorf("error preparing query ApproveDeviceAuthorization: %w", err)
+	}
 	if q.createAuthorizationCodeStmt, err = db.PrepareContext(ctx, createAuthorizationCode); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateAuthorizationCode: %w", err)
 	}
 	if q.createClientStmt, err = db.PrepareContext(ctx, createClient); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateClient: %w", err)
+	}
+	if q.createDeviceAuthorizationStmt, err = db.PrepareContext(ctx, createDeviceAuthorization); err != nil {
+		return nil, fmt.Errorf("error preparing query CreateDeviceAuthorization: %w", err)
 	}
 	if q.createOIDCSessionStmt, err = db.PrepareContext(ctx, createOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query CreateOIDCSession: %w", err)
@@ -78,11 +84,23 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteTokensByUserAndClientStmt, err = db.PrepareContext(ctx, deleteTokensByUserAndClient); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteTokensByUserAndClient: %w", err)
 	}
+	if q.denyDeviceAuthorizationStmt, err = db.PrepareContext(ctx, denyDeviceAuthorization); err != nil {
+		return nil, fmt.Errorf("error preparing query DenyDeviceAuthorization: %w", err)
+	}
+	if q.expireDeviceAuthorizationsStmt, err = db.PrepareContext(ctx, expireDeviceAuthorizations); err != nil {
+		return nil, fmt.Errorf("error preparing query ExpireDeviceAuthorizations: %w", err)
+	}
 	if q.getAuthorizationCodeStmt, err = db.PrepareContext(ctx, getAuthorizationCode); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAuthorizationCode: %w", err)
 	}
 	if q.getClientStmt, err = db.PrepareContext(ctx, getClient); err != nil {
 		return nil, fmt.Errorf("error preparing query GetClient: %w", err)
+	}
+	if q.getDeviceAuthorizationByDeviceCodeStmt, err = db.PrepareContext(ctx, getDeviceAuthorizationByDeviceCode); err != nil {
+		return nil, fmt.Errorf("error preparing query GetDeviceAuthorizationByDeviceCode: %w", err)
+	}
+	if q.getDeviceAuthorizationByUserCodeStmt, err = db.PrepareContext(ctx, getDeviceAuthorizationByUserCode); err != nil {
+		return nil, fmt.Errorf("error preparing query GetDeviceAuthorizationByUserCode: %w", err)
 	}
 	if q.getOIDCSessionStmt, err = db.PrepareContext(ctx, getOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query GetOIDCSession: %w", err)
@@ -102,6 +120,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.markAuthorizationCodeUsedStmt, err = db.PrepareContext(ctx, markAuthorizationCodeUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkAuthorizationCodeUsed: %w", err)
 	}
+	if q.touchDeviceAuthorizationStmt, err = db.PrepareContext(ctx, touchDeviceAuthorization); err != nil {
+		return nil, fmt.Errorf("error preparing query TouchDeviceAuthorization: %w", err)
+	}
 	if q.updateAuthorizationCodePKCEStmt, err = db.PrepareContext(ctx, updateAuthorizationCodePKCE); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAuthorizationCodePKCE: %w", err)
 	}
@@ -116,6 +137,11 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 
 func (q *Queries) Close() error {
 	var err error
+	if q.approveDeviceAuthorizationStmt != nil {
+		if cerr := q.approveDeviceAuthorizationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing approveDeviceAuthorizationStmt: %w", cerr)
+		}
+	}
 	if q.createAuthorizationCodeStmt != nil {
 		if cerr := q.createAuthorizationCodeStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createAuthorizationCodeStmt: %w", cerr)
@@ -124,6 +150,11 @@ func (q *Queries) Close() error {
 	if q.createClientStmt != nil {
 		if cerr := q.createClientStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing createClientStmt: %w", cerr)
+		}
+	}
+	if q.createDeviceAuthorizationStmt != nil {
+		if cerr := q.createDeviceAuthorizationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing createDeviceAuthorizationStmt: %w", cerr)
 		}
 	}
 	if q.createOIDCSessionStmt != nil {
@@ -206,6 +237,16 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing deleteTokensByUserAndClientStmt: %w", cerr)
 		}
 	}
+	if q.denyDeviceAuthorizationStmt != nil {
+		if cerr := q.denyDeviceAuthorizationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing denyDeviceAuthorizationStmt: %w", cerr)
+		}
+	}
+	if q.expireDeviceAuthorizationsStmt != nil {
+		if cerr := q.expireDeviceAuthorizationsStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing expireDeviceAuthorizationsStmt: %w", cerr)
+		}
+	}
 	if q.getAuthorizationCodeStmt != nil {
 		if cerr := q.getAuthorizationCodeStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAuthorizationCodeStmt: %w", cerr)
@@ -214,6 +255,16 @@ func (q *Queries) Close() error {
 	if q.getClientStmt != nil {
 		if cerr := q.getClientStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getClientStmt: %w", cerr)
+		}
+	}
+	if q.getDeviceAuthorizationByDeviceCodeStmt != nil {
+		if cerr := q.getDeviceAuthorizationByDeviceCodeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getDeviceAuthorizationByDeviceCodeStmt: %w", cerr)
+		}
+	}
+	if q.getDeviceAuthorizationByUserCodeStmt != nil {
+		if cerr := q.getDeviceAuthorizationByUserCodeStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getDeviceAuthorizationByUserCodeStmt: %w", cerr)
 		}
 	}
 	if q.getOIDCSessionStmt != nil {
@@ -244,6 +295,11 @@ func (q *Queries) Close() error {
 	if q.markAuthorizationCodeUsedStmt != nil {
 		if cerr := q.markAuthorizationCodeUsedStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing markAuthorizationCodeUsedStmt: %w", cerr)
+		}
+	}
+	if q.touchDeviceAuthorizationStmt != nil {
+		if cerr := q.touchDeviceAuthorizationStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing touchDeviceAuthorizationStmt: %w", cerr)
 		}
 	}
 	if q.updateAuthorizationCodePKCEStmt != nil {
@@ -298,71 +354,85 @@ func (q *Queries) queryRow(ctx context.Context, stmt *sql.Stmt, query string, ar
 }
 
 type Queries struct {
-	db                                  DBTX
-	tx                                  *sql.Tx
-	createAuthorizationCodeStmt         *sql.Stmt
-	createClientStmt                    *sql.Stmt
-	createOIDCSessionStmt               *sql.Stmt
-	createTokenStmt                     *sql.Stmt
-	deleteAllAuthorizationCodesStmt     *sql.Stmt
-	deleteAllClientsStmt                *sql.Stmt
-	deleteAllOIDCSessionsStmt           *sql.Stmt
-	deleteAllTokensStmt                 *sql.Stmt
-	deleteAuthorizationCodeStmt         *sql.Stmt
-	deleteClientStmt                    *sql.Stmt
-	deleteExpiredAuthorizationCodesStmt *sql.Stmt
-	deleteExpiredTokensStmt             *sql.Stmt
-	deleteOIDCSessionStmt               *sql.Stmt
-	deleteTokenStmt                     *sql.Stmt
-	deleteTokenByAccessTokenStmt        *sql.Stmt
-	deleteTokenByRefreshTokenStmt       *sql.Stmt
-	deleteTokensByRequestIDStmt         *sql.Stmt
-	deleteTokensByUserAndClientStmt     *sql.Stmt
-	getAuthorizationCodeStmt            *sql.Stmt
-	getClientStmt                       *sql.Stmt
-	getOIDCSessionStmt                  *sql.Stmt
-	getTokenByAccessTokenStmt           *sql.Stmt
-	getTokenByIDStmt                    *sql.Stmt
-	getTokenByRefreshTokenStmt          *sql.Stmt
-	listClientsStmt                     *sql.Stmt
-	markAuthorizationCodeUsedStmt       *sql.Stmt
-	updateAuthorizationCodePKCEStmt     *sql.Stmt
-	updateClientStmt                    *sql.Stmt
-	updateClientSecretStmt              *sql.Stmt
+	db                                     DBTX
+	tx                                     *sql.Tx
+	approveDeviceAuthorizationStmt         *sql.Stmt
+	createAuthorizationCodeStmt            *sql.Stmt
+	createClientStmt                       *sql.Stmt
+	createDeviceAuthorizationStmt          *sql.Stmt
+	createOIDCSessionStmt                  *sql.Stmt
+	createTokenStmt                        *sql.Stmt
+	deleteAllAuthorizationCodesStmt        *sql.Stmt
+	deleteAllClientsStmt                   *sql.Stmt
+	deleteAllOIDCSessionsStmt              *sql.Stmt
+	deleteAllTokensStmt                    *sql.Stmt
+	deleteAuthorizationCodeStmt            *sql.Stmt
+	deleteClientStmt                       *sql.Stmt
+	deleteExpiredAuthorizationCodesStmt    *sql.Stmt
+	deleteExpiredTokensStmt                *sql.Stmt
+	deleteOIDCSessionStmt                  *sql.Stmt
+	deleteTokenStmt                        *sql.Stmt
+	deleteTokenByAccessTokenStmt           *sql.Stmt
+	deleteTokenByRefreshTokenStmt          *sql.Stmt
+	deleteTokensByRequestIDStmt            *sql.Stmt
+	deleteTokensByUserAndClientStmt        *sql.Stmt
+	denyDeviceAuthorizationStmt            *sql.Stmt
+	expireDeviceAuthorizationsStmt         *sql.Stmt
+	getAuthorizationCodeStmt               *sql.Stmt
+	getClientStmt                          *sql.Stmt
+	getDeviceAuthorizationByDeviceCodeStmt *sql.Stmt
+	getDeviceAuthorizationByUserCodeStmt   *sql.Stmt
+	getOIDCSessionStmt                     *sql.Stmt
+	getTokenByAccessTokenStmt              *sql.Stmt
+	getTokenByIDStmt                       *sql.Stmt
+	getTokenByRefreshTokenStmt             *sql.Stmt
+	listClientsStmt                        *sql.Stmt
+	markAuthorizationCodeUsedStmt          *sql.Stmt
+	touchDeviceAuthorizationStmt           *sql.Stmt
+	updateAuthorizationCodePKCEStmt        *sql.Stmt
+	updateClientStmt                       *sql.Stmt
+	updateClientSecretStmt                 *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 	return &Queries{
-		db:                                  tx,
-		tx:                                  tx,
-		createAuthorizationCodeStmt:         q.createAuthorizationCodeStmt,
-		createClientStmt:                    q.createClientStmt,
-		createOIDCSessionStmt:               q.createOIDCSessionStmt,
-		createTokenStmt:                     q.createTokenStmt,
-		deleteAllAuthorizationCodesStmt:     q.deleteAllAuthorizationCodesStmt,
-		deleteAllClientsStmt:                q.deleteAllClientsStmt,
-		deleteAllOIDCSessionsStmt:           q.deleteAllOIDCSessionsStmt,
-		deleteAllTokensStmt:                 q.deleteAllTokensStmt,
-		deleteAuthorizationCodeStmt:         q.deleteAuthorizationCodeStmt,
-		deleteClientStmt:                    q.deleteClientStmt,
-		deleteExpiredAuthorizationCodesStmt: q.deleteExpiredAuthorizationCodesStmt,
-		deleteExpiredTokensStmt:             q.deleteExpiredTokensStmt,
-		deleteOIDCSessionStmt:               q.deleteOIDCSessionStmt,
-		deleteTokenStmt:                     q.deleteTokenStmt,
-		deleteTokenByAccessTokenStmt:        q.deleteTokenByAccessTokenStmt,
-		deleteTokenByRefreshTokenStmt:       q.deleteTokenByRefreshTokenStmt,
-		deleteTokensByRequestIDStmt:         q.deleteTokensByRequestIDStmt,
-		deleteTokensByUserAndClientStmt:     q.deleteTokensByUserAndClientStmt,
-		getAuthorizationCodeStmt:            q.getAuthorizationCodeStmt,
-		getClientStmt:                       q.getClientStmt,
-		getOIDCSessionStmt:                  q.getOIDCSessionStmt,
-		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
-		getTokenByIDStmt:                    q.getTokenByIDStmt,
-		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
-		listClientsStmt:                     q.listClientsStmt,
-		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
-		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,
-		updateClientStmt:                    q.updateClientStmt,
-		updateClientSecretStmt:              q.updateClientSecretStmt,
+		db:                                     tx,
+		tx:                                     tx,
+		approveDeviceAuthorizationStmt:         q.approveDeviceAuthorizationStmt,
+		createAuthorizationCodeStmt:            q.createAuthorizationCodeStmt,
+		createClientStmt:                       q.createClientStmt,
+		createDeviceAuthorizationStmt:          q.createDeviceAuthorizationStmt,
+		createOIDCSessionStmt:                  q.createOIDCSessionStmt,
+		createTokenStmt:                        q.createTokenStmt,
+		deleteAllAuthorizationCodesStmt:        q.deleteAllAuthorizationCodesStmt,
+		deleteAllClientsStmt:                   q.deleteAllClientsStmt,
+		deleteAllOIDCSessionsStmt:              q.deleteAllOIDCSessionsStmt,
+		deleteAllTokensStmt:                    q.deleteAllTokensStmt,
+		deleteAuthorizationCodeStmt:            q.deleteAuthorizationCodeStmt,
+		deleteClientStmt:                       q.deleteClientStmt,
+		deleteExpiredAuthorizationCodesStmt:    q.deleteExpiredAuthorizationCodesStmt,
+		deleteExpiredTokensStmt:                q.deleteExpiredTokensStmt,
+		deleteOIDCSessionStmt:                  q.deleteOIDCSessionStmt,
+		deleteTokenStmt:                        q.deleteTokenStmt,
+		deleteTokenByAccessTokenStmt:           q.deleteTokenByAccessTokenStmt,
+		deleteTokenByRefreshTokenStmt:          q.deleteTokenByRefreshTokenStmt,
+		deleteTokensByRequestIDStmt:            q.deleteTokensByRequestIDStmt,
+		deleteTokensByUserAndClientStmt:        q.deleteTokensByUserAndClientStmt,
+		denyDeviceAuthorizationStmt:            q.denyDeviceAuthorizationStmt,
+		expireDeviceAuthorizationsStmt:         q.expireDeviceAuthorizationsStmt,
+		getAuthorizationCodeStmt:               q.getAuthorizationCodeStmt,
+		getClientStmt:                          q.getClientStmt,
+		getDeviceAuthorizationByDeviceCodeStmt: q.getDeviceAuthorizationByDeviceCodeStmt,
+		getDeviceAuthorizationByUserCodeStmt:   q.getDeviceAuthorizationByUserCodeStmt,
+		getOIDCSessionStmt:                     q.getOIDCSessionStmt,
+		getTokenByAccessTokenStmt:              q.getTokenByAccessTokenStmt,
+		getTokenByIDStmt:                       q.getTokenByIDStmt,
+		getTokenByRefreshTokenStmt:             q.getTokenByRefreshTokenStmt,
+		listClientsStmt:                        q.listClientsStmt,
+		markAuthorizationCodeUsedStmt:          q.markAuthorizationCodeUsedStmt,
+		touchDeviceAuthorizationStmt:           q.touchDeviceAuthorizationStmt,
+		updateAuthorizationCodePKCEStmt:        q.updateAuthorizationCodePKCEStmt,
+		updateClientStmt:                       q.updateClientStmt,
+		updateClientSecretStmt:                 q.updateClientSecretStmt,
 	}
 }

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -36,6 +36,21 @@ type Client struct {
 	UpdatedAt        time.Time       `json:"updated_at"`
 }
 
+type DeviceAuthorization struct {
+	ID           uuid.UUID     `json:"id"`
+	DeviceCode   string        `json:"device_code"`
+	UserCode     string        `json:"user_code"`
+	ClientID     uuid.UUID     `json:"client_id"`
+	UserID       uuid.NullUUID `json:"user_id"`
+	Scopes       string        `json:"scopes"`
+	Status       string        `json:"status"`
+	ExpiresAt    time.Time     `json:"expires_at"`
+	PollInterval int32         `json:"poll_interval"`
+	LastPolledAt sql.NullTime  `json:"last_polled_at"`
+	AuthorizedAt sql.NullTime  `json:"authorized_at"`
+	CreatedAt    time.Time     `json:"created_at"`
+}
+
 type OidcSession struct {
 	AuthorizeCode string         `json:"authorize_code"`
 	ClientID      uuid.UUID      `json:"client_id"`

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -14,6 +14,22 @@ import (
 	"github.com/google/uuid"
 )
 
+const approveDeviceAuthorization = `-- name: ApproveDeviceAuthorization :exec
+UPDATE device_authorizations
+SET status = 'authorized', user_id = $2, authorized_at = CURRENT_TIMESTAMP
+WHERE id = $1 AND status = 'pending'
+`
+
+type ApproveDeviceAuthorizationParams struct {
+	ID     uuid.UUID     `json:"id"`
+	UserID uuid.NullUUID `json:"user_id"`
+}
+
+func (q *Queries) ApproveDeviceAuthorization(ctx context.Context, arg ApproveDeviceAuthorizationParams) error {
+	_, err := q.exec(ctx, q.approveDeviceAuthorizationStmt, approveDeviceAuthorization, arg.ID, arg.UserID)
+	return err
+}
+
 const createAuthorizationCode = `-- name: CreateAuthorizationCode :exec
 
 INSERT INTO authorization_codes (
@@ -84,6 +100,43 @@ func (q *Queries) CreateClient(ctx context.Context, arg CreateClientParams) erro
 		arg.Name,
 		arg.ClientType,
 		arg.RedirectUris,
+	)
+	return err
+}
+
+const createDeviceAuthorization = `-- name: CreateDeviceAuthorization :exec
+
+INSERT INTO device_authorizations (
+    id,
+    device_code,
+    user_code,
+    client_id,
+    scopes,
+    expires_at,
+    poll_interval
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+`
+
+type CreateDeviceAuthorizationParams struct {
+	ID           uuid.UUID `json:"id"`
+	DeviceCode   string    `json:"device_code"`
+	UserCode     string    `json:"user_code"`
+	ClientID     uuid.UUID `json:"client_id"`
+	Scopes       string    `json:"scopes"`
+	ExpiresAt    time.Time `json:"expires_at"`
+	PollInterval int32     `json:"poll_interval"`
+}
+
+// Device authorization queries (RFC 8628)
+func (q *Queries) CreateDeviceAuthorization(ctx context.Context, arg CreateDeviceAuthorizationParams) error {
+	_, err := q.exec(ctx, q.createDeviceAuthorizationStmt, createDeviceAuthorization,
+		arg.ID,
+		arg.DeviceCode,
+		arg.UserCode,
+		arg.ClientID,
+		arg.Scopes,
+		arg.ExpiresAt,
+		arg.PollInterval,
 	)
 	return err
 }
@@ -296,6 +349,28 @@ func (q *Queries) DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTok
 	return err
 }
 
+const denyDeviceAuthorization = `-- name: DenyDeviceAuthorization :exec
+UPDATE device_authorizations
+SET status = 'denied'
+WHERE id = $1 AND status = 'pending'
+`
+
+func (q *Queries) DenyDeviceAuthorization(ctx context.Context, id uuid.UUID) error {
+	_, err := q.exec(ctx, q.denyDeviceAuthorizationStmt, denyDeviceAuthorization, id)
+	return err
+}
+
+const expireDeviceAuthorizations = `-- name: ExpireDeviceAuthorizations :exec
+UPDATE device_authorizations
+SET status = 'expired'
+WHERE status = 'pending' AND expires_at < CURRENT_TIMESTAMP
+`
+
+func (q *Queries) ExpireDeviceAuthorizations(ctx context.Context) error {
+	_, err := q.exec(ctx, q.expireDeviceAuthorizationsStmt, expireDeviceAuthorizations)
+	return err
+}
+
 const getAuthorizationCode = `-- name: GetAuthorizationCode :one
 SELECT code, client_id, user_id, redirect_uri, scopes, code_challenge, code_challenge_method, nonce, used, expires_at, created_at FROM authorization_codes WHERE code = $1
 `
@@ -334,6 +409,54 @@ func (q *Queries) GetClient(ctx context.Context, clientID uuid.UUID) (Client, er
 		&i.RedirectUris,
 		&i.CreatedAt,
 		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const getDeviceAuthorizationByDeviceCode = `-- name: GetDeviceAuthorizationByDeviceCode :one
+SELECT id, device_code, user_code, client_id, user_id, scopes, status, expires_at, poll_interval, last_polled_at, authorized_at, created_at FROM device_authorizations WHERE device_code = $1
+`
+
+func (q *Queries) GetDeviceAuthorizationByDeviceCode(ctx context.Context, deviceCode string) (DeviceAuthorization, error) {
+	row := q.queryRow(ctx, q.getDeviceAuthorizationByDeviceCodeStmt, getDeviceAuthorizationByDeviceCode, deviceCode)
+	var i DeviceAuthorization
+	err := row.Scan(
+		&i.ID,
+		&i.DeviceCode,
+		&i.UserCode,
+		&i.ClientID,
+		&i.UserID,
+		&i.Scopes,
+		&i.Status,
+		&i.ExpiresAt,
+		&i.PollInterval,
+		&i.LastPolledAt,
+		&i.AuthorizedAt,
+		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getDeviceAuthorizationByUserCode = `-- name: GetDeviceAuthorizationByUserCode :one
+SELECT id, device_code, user_code, client_id, user_id, scopes, status, expires_at, poll_interval, last_polled_at, authorized_at, created_at FROM device_authorizations WHERE user_code = $1
+`
+
+func (q *Queries) GetDeviceAuthorizationByUserCode(ctx context.Context, userCode string) (DeviceAuthorization, error) {
+	row := q.queryRow(ctx, q.getDeviceAuthorizationByUserCodeStmt, getDeviceAuthorizationByUserCode, userCode)
+	var i DeviceAuthorization
+	err := row.Scan(
+		&i.ID,
+		&i.DeviceCode,
+		&i.UserCode,
+		&i.ClientID,
+		&i.UserID,
+		&i.Scopes,
+		&i.Status,
+		&i.ExpiresAt,
+		&i.PollInterval,
+		&i.LastPolledAt,
+		&i.AuthorizedAt,
+		&i.CreatedAt,
 	)
 	return i, err
 }
@@ -462,6 +585,17 @@ UPDATE authorization_codes SET used = TRUE WHERE code = $1
 
 func (q *Queries) MarkAuthorizationCodeUsed(ctx context.Context, code string) error {
 	_, err := q.exec(ctx, q.markAuthorizationCodeUsedStmt, markAuthorizationCodeUsed, code)
+	return err
+}
+
+const touchDeviceAuthorization = `-- name: TouchDeviceAuthorization :exec
+UPDATE device_authorizations
+SET last_polled_at = CURRENT_TIMESTAMP
+WHERE device_code = $1
+`
+
+func (q *Queries) TouchDeviceAuthorization(ctx context.Context, deviceCode string) error {
+	_, err := q.exec(ctx, q.touchDeviceAuthorizationStmt, touchDeviceAuthorization, deviceCode)
 	return err
 }
 

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -12,10 +12,13 @@ import (
 )
 
 type Querier interface {
+	ApproveDeviceAuthorization(ctx context.Context, arg ApproveDeviceAuthorizationParams) error
 	// Authorization Code queries
 	CreateAuthorizationCode(ctx context.Context, arg CreateAuthorizationCodeParams) error
 	// Client queries
 	CreateClient(ctx context.Context, arg CreateClientParams) error
+	// Device authorization queries (RFC 8628)
+	CreateDeviceAuthorization(ctx context.Context, arg CreateDeviceAuthorizationParams) error
 	// OIDC Session queries
 	CreateOIDCSession(ctx context.Context, arg CreateOIDCSessionParams) error
 	// Token queries
@@ -34,14 +37,19 @@ type Querier interface {
 	DeleteTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) error
 	DeleteTokensByRequestID(ctx context.Context, requestID string) error
 	DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTokensByUserAndClientParams) error
+	DenyDeviceAuthorization(ctx context.Context, id uuid.UUID) error
+	ExpireDeviceAuthorizations(ctx context.Context) error
 	GetAuthorizationCode(ctx context.Context, code string) (AuthorizationCode, error)
 	GetClient(ctx context.Context, clientID uuid.UUID) (Client, error)
+	GetDeviceAuthorizationByDeviceCode(ctx context.Context, deviceCode string) (DeviceAuthorization, error)
+	GetDeviceAuthorizationByUserCode(ctx context.Context, userCode string) (DeviceAuthorization, error)
 	GetOIDCSession(ctx context.Context, authorizeCode string) (OidcSession, error)
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
 	ListClients(ctx context.Context) ([]Client, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
+	TouchDeviceAuthorization(ctx context.Context, deviceCode string) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error
 	UpdateClient(ctx context.Context, arg UpdateClientParams) error
 	UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -179,11 +179,19 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
-		Issuer:      "http://localhost:8080",
-		Environment: "development",
-		TestUserID:  "00000000-0000-0000-0000-000000000000",
-	})
+	tokenRepo := repository.NewTokenRepository(queries)
+	deviceAuthRepo := repository.NewDeviceAuthorizationRepository(queries)
+	tokenStrategy := compose.NewOAuth2HMACStrategy(fositeConfig)
+
+	handler := NewHandler(
+		clientUseCase, oauthUsecase, oauth2Provider, tokenStrategy, nil,
+		tokenRepo, deviceAuthRepo,
+		OAuthConfig{
+			Issuer:      "http://localhost:8080",
+			Environment: "development",
+			TestUserID:  "00000000-0000-0000-0000-000000000000",
+		},
+	)
 
 	cleanup := func() {
 		_ = queries.DeleteAllClients(ctx)

--- a/internal/router/v1/device.go
+++ b/internal/router/v1/device.go
@@ -1,0 +1,344 @@
+package v1
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"html"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/ory/fosite"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository"
+	"github.com/traPtitech/portal-oidc/internal/repository/oauth"
+)
+
+const (
+	deviceCodeBytes        = 32
+	userCodeChars          = "BCDFGHJKLMNPQRSTVWXZ" // exclude vowels and 0/1/I/O for human entry
+	userCodeLength         = 8
+	deviceAuthorizationTTL = 10 * time.Minute
+	devicePollInterval     = 5
+)
+
+// DeviceAuthorize implements RFC 8628 §3.1 (Device Authorization Request).
+// The device POSTs client_id (and optional scope) and receives a device_code
+// it polls with, plus a user_code the human types into a browser.
+//
+// Refs:
+//   - RFC 8628 §3.1 (Device Authorization Request)
+//     https://datatracker.ietf.org/doc/html/rfc8628#section-3.1
+//   - RFC 8628 §3.2 (Device Authorization Response)
+//     https://datatracker.ietf.org/doc/html/rfc8628#section-3.2
+func (h *Handler) DeviceAuthorize(ctx *echo.Context) error {
+	clientID := ctx.FormValue("client_id")
+	scope := ctx.FormValue("scope")
+	if clientID == "" {
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("invalid_request", "client_id is required"))
+	}
+	cid, err := uuid.Parse(clientID)
+	if err != nil {
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("invalid_client", "client_id must be a UUID"))
+	}
+	if _, err := h.clientUseCase.Get(ctx.Request().Context(), cid); err != nil {
+		return ctx.JSON(http.StatusUnauthorized, oauthErrorJSON("invalid_client", "unknown client"))
+	}
+
+	deviceCode, err := randomDeviceCode()
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", err.Error()))
+	}
+	userCode, err := randomUserCode()
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", err.Error()))
+	}
+
+	expires := time.Now().Add(deviceAuthorizationTTL)
+	auth := domain.DeviceAuthorization{
+		DeviceCode:   deviceCode,
+		UserCode:     userCode,
+		ClientID:     cid,
+		Scopes:       splitScopeField(scope),
+		Status:       domain.DeviceAuthorizationStatusPending,
+		ExpiresAt:    expires,
+		PollInterval: devicePollInterval,
+	}
+	if err := h.deviceAuths.Create(ctx.Request().Context(), auth); err != nil {
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", err.Error()))
+	}
+
+	issuer := strings.TrimRight(h.config.Issuer, "/")
+	return ctx.JSON(http.StatusOK, map[string]any{
+		"device_code":               deviceCode,
+		"user_code":                 userCode,
+		"verification_uri":          issuer + "/oauth2/device",
+		"verification_uri_complete": issuer + "/oauth2/device?user_code=" + userCode,
+		"expires_in":                int(deviceAuthorizationTTL.Seconds()),
+		"interval":                  devicePollInterval,
+	})
+}
+
+// GetDeviceVerification renders the user-facing form where the human enters
+// the user_code displayed by the device. The user_code may also arrive
+// pre-filled via the verification_uri_complete query parameter.
+func (h *Handler) GetDeviceVerification(ctx *echo.Context) error {
+	prefill := ctx.QueryParam("user_code")
+	page := `<!DOCTYPE html>
+<html>
+<head>
+    <title>Device Authorization</title>
+    <style>
+        body { font-family: sans-serif; max-width: 420px; margin: 100px auto; padding: 20px; }
+        input { padding: 10px; font-size: 18px; text-transform: uppercase; letter-spacing: 4px; width: 100%; box-sizing: border-box; }
+        button { padding: 12px; font-size: 16px; background: #007bff; color: white; border: none; cursor: pointer; width: 100%; margin-top: 12px; }
+    </style>
+</head>
+<body>
+    <h1>Authorize Device</h1>
+    <p>Enter the code shown on your device:</p>
+    <form method="POST" action="/oauth2/device">
+        <input type="text" name="user_code" placeholder="ABCD-EFGH" required autofocus value="` + html.EscapeString(prefill) + `">
+        <button type="submit">Continue</button>
+    </form>
+</body>
+</html>`
+	return ctx.HTML(http.StatusOK, page)
+}
+
+// PostDeviceVerification processes the user's submission of a user_code,
+// requires login, then either displays a consent form or, on a follow-up
+// "approve" submission, marks the authorization as approved.
+func (h *Handler) PostDeviceVerification(ctx *echo.Context) error {
+	userCode := strings.ToUpper(strings.TrimSpace(ctx.FormValue("user_code")))
+	action := ctx.FormValue("action")
+	if userCode == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "user_code required")
+	}
+
+	auth, err := h.deviceAuths.GetByUserCode(ctx.Request().Context(), userCode)
+	if err != nil {
+		if errors.Is(err, repository.ErrDeviceAuthorizationNotFound) {
+			return ctx.HTML(http.StatusNotFound, `<h1>Invalid code</h1>`)
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if auth.IsExpired(time.Now()) || auth.Status != domain.DeviceAuthorizationStatusPending {
+		return ctx.HTML(http.StatusGone, `<h1>This code is no longer valid</h1>`)
+	}
+
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		// Bounce through /login carrying the user_code so the verification
+		// form is pre-filled when we come back.
+		return ctx.Redirect(http.StatusFound, "/login?return_url="+
+			"%2Foauth2%2Fdevice%3Fuser_code%3D"+userCode)
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+
+	switch action {
+	case "approve":
+		if err := h.deviceAuths.Approve(ctx.Request().Context(), auth.ID, userID); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return ctx.HTML(http.StatusOK, `<h1>Device authorized</h1><p>You may close this window.</p>`)
+	case "deny":
+		if err := h.deviceAuths.Deny(ctx.Request().Context(), auth.ID); err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+		}
+		return ctx.HTML(http.StatusOK, `<h1>Authorization denied</h1>`)
+	}
+
+	// Show consent form.
+	scopeList := ""
+	for _, s := range auth.Scopes {
+		scopeList += "<li>" + html.EscapeString(s) + "</li>"
+	}
+	if scopeList == "" {
+		scopeList = "<li>(no scopes requested)</li>"
+	}
+	page := `<!DOCTYPE html>
+<html>
+<head><title>Authorize Device</title></head>
+<body style="font-family: sans-serif; max-width: 420px; margin: 80px auto;">
+    <h1>Authorize this device?</h1>
+    <p>The device requesting access wants:</p>
+    <ul>` + scopeList + `</ul>
+    <form method="POST" action="/oauth2/device">
+        <input type="hidden" name="user_code" value="` + html.EscapeString(userCode) + `">
+        <button type="submit" name="action" value="deny">Deny</button>
+        <button type="submit" name="action" value="approve">Allow</button>
+    </form>
+</body>
+</html>`
+	return ctx.HTML(http.StatusOK, page)
+}
+
+// DeviceTokenGrant handles grant_type=urn:ietf:params:oauth:grant-type:device_code
+// at the token endpoint. RFC 8628 §3.5 specifies the polling response codes:
+// authorization_pending while the user has not finished the ceremony,
+// access_denied if they refused, expired_token after the TTL, slow_down to
+// throttle aggressive pollers (we approximate by enforcing the stored
+// interval), and a normal token response on success.
+//
+// Refs:
+//   - RFC 8628 §3.4 (Device Access Token Request)
+//     https://datatracker.ietf.org/doc/html/rfc8628#section-3.4
+//   - RFC 8628 §3.5 (Device Access Token Response)
+//     https://datatracker.ietf.org/doc/html/rfc8628#section-3.5
+func (h *Handler) DeviceTokenGrant(ctx *echo.Context) error {
+	deviceCode := ctx.FormValue("device_code")
+	if deviceCode == "" {
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("invalid_request", "device_code is required"))
+	}
+
+	auth, err := h.deviceAuths.GetByDeviceCode(ctx.Request().Context(), deviceCode)
+	if err != nil {
+		if errors.Is(err, repository.ErrDeviceAuthorizationNotFound) {
+			return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("invalid_grant", "unknown device_code"))
+		}
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", err.Error()))
+	}
+
+	if auth.IsExpired(time.Now()) {
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("expired_token", "device_code has expired"))
+	}
+	if auth.LastPolledAt != nil && time.Since(*auth.LastPolledAt) < time.Duration(auth.PollInterval)*time.Second {
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("slow_down", "polling too quickly"))
+	}
+	if err := h.deviceAuths.Touch(ctx.Request().Context(), deviceCode); err != nil {
+		// Best-effort throttle bookkeeping — proceed even on failure.
+		_ = err
+	}
+
+	switch auth.Status {
+	case domain.DeviceAuthorizationStatusPending:
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("authorization_pending", "user has not yet completed authorization"))
+	case domain.DeviceAuthorizationStatusDenied:
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("access_denied", "the user denied the request"))
+	case domain.DeviceAuthorizationStatusExpired:
+		return ctx.JSON(http.StatusBadRequest, oauthErrorJSON("expired_token", "device_code has expired"))
+	case domain.DeviceAuthorizationStatusAuthorized:
+		// fall through
+	default:
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", "unknown status"))
+	}
+
+	if auth.UserID == nil {
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", "authorized device without user"))
+	}
+
+	resp, err := h.issueDeviceTokens(ctx, auth)
+	if err != nil {
+		return ctx.JSON(http.StatusInternalServerError, oauthErrorJSON("server_error", err.Error()))
+	}
+	return ctx.JSON(http.StatusOK, resp)
+}
+
+// issueDeviceTokens mints fosite-compatible HMAC tokens via the shared
+// strategy so /userinfo and /introspect can validate them like any other
+// access token. The persisted JTI / token_hash are the signature halves of
+// the HMAC tokens, matching how the regular grants store them.
+func (h *Handler) issueDeviceTokens(ctx *echo.Context, auth domain.DeviceAuthorization) (map[string]any, error) {
+	c := ctx.Request().Context()
+	requestID := uuid.New().String()
+
+	requester := &fosite.Request{
+		ID:          requestID,
+		RequestedAt: time.Now(),
+		Client: &oauth.Client{
+			ID:           auth.ClientID.String(),
+			RedirectURIs: []string{},
+			GrantTypes:   []string{"urn:ietf:params:oauth:grant-type:device_code"},
+		},
+		Session: oauth.NewSession(auth.UserID.String(), time.Now()),
+	}
+	requester.SetRequestedScopes(auth.Scopes)
+	for _, s := range auth.Scopes {
+		requester.GrantScope(s)
+	}
+
+	accessToken, accessSig, err := h.tokenStrategy.GenerateAccessToken(c, requester)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	accessExpires := now.Add(time.Hour) // matches default lifespan; follow-up: pull from config
+
+	if err := h.tokens.Create(c, domain.Token{
+		ID:          uuid.New(),
+		RequestID:   requestID,
+		ClientID:    auth.ClientID,
+		UserID:      *auth.UserID,
+		AccessToken: accessSig,
+		Scopes:      auth.Scopes,
+		ExpiresAt:   accessExpires,
+	}); err != nil {
+		return nil, err
+	}
+
+	// RFC 8628 §3.5: refresh_token is OPTIONAL in the device access token
+	// response. The combined tokens table on main has a UNIQUE access_token
+	// constraint that breaks two refresh-only rows; emitting a refresh token
+	// here is deferred until the access_tokens / refresh_tokens split lands.
+	return map[string]any{
+		"access_token": accessToken,
+		"token_type":   "Bearer",
+		"expires_in":   int(time.Until(accessExpires).Seconds()),
+		"scope":        strings.Join(auth.Scopes, " "),
+	}, nil
+}
+
+func randomDeviceCode() (string, error) {
+	buf := make([]byte, deviceCodeBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}
+
+func randomUserCode() (string, error) {
+	// User codes are read aloud and typed; restrict the alphabet to
+	// unambiguous characters and split with a hyphen for legibility.
+	out := make([]byte, userCodeLength)
+	for i := range out {
+		idx, err := randomIndex(len(userCodeChars))
+		if err != nil {
+			return "", err
+		}
+		out[i] = userCodeChars[idx]
+	}
+	mid := userCodeLength / 2
+	return string(out[:mid]) + "-" + string(out[mid:]), nil
+}
+
+func randomIndex(n int) (int, error) {
+	buf := make([]byte, 1)
+	if _, err := rand.Read(buf); err != nil {
+		return 0, err
+	}
+	return int(buf[0]) % n, nil
+}
+
+func splitScopeField(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Fields(s)
+}
+
+func oauthErrorJSON(code, description string) map[string]any {
+	out := map[string]any{"error": code}
+	if description != "" {
+		out["error_description"] = description
+	}
+	return out
+}

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
 
+	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -15,7 +17,10 @@ type Handler struct {
 	clientUseCase usecase.ClientUseCase
 	oauthUseCase  usecase.OAuthUseCase
 	oauth2        fosite.OAuth2Provider
+	tokenStrategy *oauth2.HMACSHAStrategy
 	userUseCase   usecase.UserUseCase
+	tokens        repository.TokenRepository
+	deviceAuths   repository.DeviceAuthorizationRepository
 	sessions      *sessions.CookieStore
 	config        OAuthConfig
 }
@@ -31,8 +36,11 @@ type OAuthConfig struct {
 func NewHandler(
 	clientUseCase usecase.ClientUseCase,
 	oauthUseCase usecase.OAuthUseCase,
-	oauth2 fosite.OAuth2Provider,
+	oauth2Provider fosite.OAuth2Provider,
+	tokenStrategy *oauth2.HMACSHAStrategy,
 	userUseCase usecase.UserUseCase,
+	tokens repository.TokenRepository,
+	deviceAuths repository.DeviceAuthorizationRepository,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -47,8 +55,11 @@ func NewHandler(
 	return &Handler{
 		clientUseCase: clientUseCase,
 		oauthUseCase:  oauthUseCase,
-		oauth2:        oauth2,
+		oauth2:        oauth2Provider,
+		tokenStrategy: tokenStrategy,
 		userUseCase:   userUseCase,
+		tokens:        tokens,
+		deviceAuths:   deviceAuths,
 		sessions:      store,
 		config:        config,
 	}

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -159,6 +159,12 @@ func (h *Handler) Token(ctx *echo.Context) error {
 	rw := ctx.Response()
 	req := ctx.Request()
 
+	// RFC 8628 §3.4 introduces a grant_type fosite v0.49 does not natively
+	// support, so peek before the standard fosite path takes over.
+	if err := req.ParseForm(); err == nil && req.Form.Get("grant_type") == "urn:ietf:params:oauth:grant-type:device_code" {
+		return h.DeviceTokenGrant(ctx)
+	}
+
 	session := oauth.NewSession("", time.Time{})
 	accessRequest, err := h.oauth2.NewAccessRequest(c, req, session)
 	if err != nil {


### PR DESCRIPTION
## 概要

OAuth 2.0 Device Authorization Grant (RFC 8628) を手動実装。CLI / IoT 等のブラウザを持たないクライアント向けの認可フロー。fosite v0.49 が RFC 8628 未対応なので独自実装。

## エンドポイント

| メソッド | パス | 用途 |
|---|---|---|
| POST | \`/oauth2/device/code\` | デバイスが authorization 開始 (RFC 8628 §3.1) |
| GET | \`/oauth2/device\` | ユーザが user_code を入力するフォーム |
| POST | \`/oauth2/device\` | ユーザの user_code 送信 → consent → 承認/拒否 |
| POST | \`/oauth2/token\` | \`grant_type=urn:ietf:params:oauth:grant-type:device_code\` を fosite 前段で intercept |

## 変更

### スキーマ
- \`db/schema.sql\`: \`device_authorizations\` テーブル追加
  - \`(device_code)\` / \`(user_code)\` UNIQUE
  - \`status\` CHECK で \`pending|authorized|denied|expired\` 列挙
  - \`poll_interval\` で per-row throttle ヒント

### Domain / Repository
- \`internal/domain/device.go\`: \`DeviceAuthorization\` + status enum + \`IsExpired\` ヘルパー
- \`internal/repository/device.go\`: \`DeviceAuthorizationRepository\` 実装

### Handler
- \`internal/router/v1/device.go\` (新規):
  - \`DeviceAuthorize\` (RFC 8628 §3.1): \`device_code\` (32 byte ランダム) + \`user_code\` (8 文字、母音と 0/1/I/O 除外で人間が読みやすく) を発行
  - \`GetDeviceVerification\` / \`PostDeviceVerification\`: ユーザ向け code 入力 + 承認/拒否 UI
  - \`DeviceTokenGrant\` (RFC 8628 §3.5): polling status 応答 (\`authorization_pending\` / \`access_denied\` / \`expired_token\` / \`slow_down\`)
  - \`issueDeviceTokens\`: fosite と共有の HMAC strategy で access_token 発行 → \`/userinfo\` / \`/introspect\` で検証可能
- \`internal/router/v1/oauth.go\`: \`Token\` handler 冒頭で device_code grant を検出して \`DeviceTokenGrant\` へ振り分け

### 共有コンポーネント
- \`cmd/oauth.go\`: \`newTokenStrategy\` を export (fosite と device flow 両方が使う)
- \`internal/router/v1/handler.go\`: \`tokenStrategy\` / \`tokens\` / \`deviceAuths\` フィールド追加

## 制限事項 (本 PR で意図的に未対応)

- **refresh_token を device flow 応答に含めない** (RFC 8628 §3.5 で OPTIONAL)。tokens テーブルの UNIQUE access_token 制約により refresh-only row 2 件目で衝突。PR #141 (tokens 分離) マージ後に follow-up
- **device_authorization_endpoint を discovery に advertise しない** (PR #131 で別 follow-up)
- **discoverable credential / usernameless WebAuthn** との統合は別途
- **audit log hook** は別 PR

## RFC / 仕様根拠

| 項目 | RFC | 該当節 |
|---|---|---|
| Device Authorization Request | RFC 8628 | [§3.1](https://datatracker.ietf.org/doc/html/rfc8628#section-3.1) |
| Device Authorization Response | RFC 8628 | [§3.2](https://datatracker.ietf.org/doc/html/rfc8628#section-3.2) |
| User Interaction | RFC 8628 | [§3.3](https://datatracker.ietf.org/doc/html/rfc8628#section-3.3) |
| Device Access Token Request/Response | RFC 8628 | [§3.4 / §3.5](https://datatracker.ietf.org/doc/html/rfc8628#section-3.4) |
| User Code Recommendations | RFC 8628 | [§6.1](https://datatracker.ietf.org/doc/html/rfc8628#section-6.1) |

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite / Security Scan) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` / \`gosec\` 0 issues (確認済み)
- [ ] 手動: device 側 \`curl POST /oauth2/device/code\` → user_code を表示
- [ ] 手動: ブラウザで /oauth2/device 入力 → consent → approve
- [ ] 手動: device 側 \`curl POST /oauth2/token grant_type=urn:ietf:params:oauth:grant-type:device_code\` でトークン取得 → /userinfo で検証