### PR TITLE
feat(auth): TOTP 登録・検証・ログインエンドポイント追加 (RFC 6238)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -60,11 +60,13 @@ func newServer(cfg Config) (http.Handler, error) {
 		}
 		userUseCase = usecase.NewUserUseCase(repository.NewUserRepository(portalQueries))
 	}
+	totpRepo := repository.NewTOTPCredentialRepository(queries)
 	handler := v1.NewHandler(
 		usecase.NewClientUseCase(clientRepo),
 		usecase.NewOAuthUseCase(),
 		oauth2Provider,
 		userUseCase,
+		totpRepo,
 		v1.OAuthConfig{
 			Issuer:        cfg.Host,
 			SessionSecret: []byte(cfg.OAuth.Secret),
@@ -82,6 +84,11 @@ func newServer(cfg Config) (http.Handler, error) {
 		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}))
 	gen.RegisterHandlers(e, handler)
+	e.POST("/auth/totp/register", handler.RegisterTOTP)
+	e.POST("/auth/totp/register/verify", handler.VerifyTOTPRegistration)
+	e.POST("/auth/totp/login", handler.LoginTOTP)
+	e.GET("/auth/totp", handler.GetTOTPStatus)
+	e.DELETE("/auth/totp", handler.DisableTOTP)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
 	e.GET("/logout", handler.Logout)

--- a/db/query/oidc.sql
+++ b/db/query/oidc.sql
@@ -134,3 +134,31 @@ DELETE FROM oidc_sessions WHERE authorize_code = $1;
 
 -- name: DeleteAllOIDCSessions :exec
 DELETE FROM oidc_sessions;
+
+-- TOTP queries
+
+-- name: UpsertTOTPCredential :exec
+-- Insert a new secret or replace the existing one when the user re-enrols.
+-- enabled stays at the supplied value so we can distinguish "secret stored,
+-- waiting for first verification" from "secret in active use".
+INSERT INTO totp_credentials (user_id, secret, enabled)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id) DO UPDATE SET
+    secret = EXCLUDED.secret,
+    enabled = EXCLUDED.enabled,
+    created_at = CURRENT_TIMESTAMP,
+    last_used_at = NULL;
+
+-- name: GetTOTPCredential :one
+SELECT * FROM totp_credentials WHERE user_id = $1;
+
+-- name: EnableTOTPCredential :exec
+UPDATE totp_credentials SET enabled = TRUE, last_used_at = CURRENT_TIMESTAMP
+WHERE user_id = $1;
+
+-- name: TouchTOTPCredential :exec
+UPDATE totp_credentials SET last_used_at = CURRENT_TIMESTAMP
+WHERE user_id = $1;
+
+-- name: DeleteTOTPCredential :exec
+DELETE FROM totp_credentials WHERE user_id = $1;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -78,3 +78,16 @@ CREATE TABLE IF NOT EXISTS oidc_sessions (
 );
 
 CREATE INDEX IF NOT EXISTS idx_oidc_sessions_client_id ON oidc_sessions (client_id);
+
+-- traPortal v2 spec §TOTP
+-- One TOTP shared secret per user. enabled flips to true only after the user
+-- has proven possession by typing back a valid code, so a half-finished
+-- enrolment never blocks login.
+CREATE TABLE IF NOT EXISTS totp_credentials (
+  user_id UUID NOT NULL,
+  secret TEXT NOT NULL,
+  enabled BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  last_used_at TIMESTAMPTZ NULL,
+  PRIMARY KEY (user_id)
+);

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/labstack/echo/v5 v5.1.1
 	github.com/oapi-codegen/runtime v1.4.0
 	github.com/ory/fosite v0.49.0
+	github.com/pquerna/otp v1.5.0
 	github.com/sqlc-dev/pqtype v0.3.0
 	golang.org/x/crypto v0.50.0
 )
@@ -23,6 +24,7 @@ require (
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cristalhq/jwt/v4 v4.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
+github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -374,6 +376,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
+github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=

--- a/internal/domain/totp.go
+++ b/internal/domain/totp.go
@@ -1,0 +1,19 @@
+package domain
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TOTPCredential is a user's TOTP shared secret. Enabled flips to true only
+// once the user has typed back a valid code during enrolment, so a partial
+// enrolment never gates login (RFC 6238 §3 implies the verifier must validate
+// at least one OTP before trusting the seed).
+type TOTPCredential struct {
+	UserID     uuid.UUID
+	Secret     string
+	Enabled    bool
+	CreatedAt  time.Time
+	LastUsedAt *time.Time
+}

--- a/internal/repository/oidc/db.go
+++ b/internal/repository/oidc/db.go
@@ -63,6 +63,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteOIDCSessionStmt, err = db.PrepareContext(ctx, deleteOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteOIDCSession: %w", err)
 	}
+	if q.deleteTOTPCredentialStmt, err = db.PrepareContext(ctx, deleteTOTPCredential); err != nil {
+		return nil, fmt.Errorf("error preparing query DeleteTOTPCredential: %w", err)
+	}
 	if q.deleteTokenStmt, err = db.PrepareContext(ctx, deleteToken); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteToken: %w", err)
 	}
@@ -78,6 +81,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.deleteTokensByUserAndClientStmt, err = db.PrepareContext(ctx, deleteTokensByUserAndClient); err != nil {
 		return nil, fmt.Errorf("error preparing query DeleteTokensByUserAndClient: %w", err)
 	}
+	if q.enableTOTPCredentialStmt, err = db.PrepareContext(ctx, enableTOTPCredential); err != nil {
+		return nil, fmt.Errorf("error preparing query EnableTOTPCredential: %w", err)
+	}
 	if q.getAuthorizationCodeStmt, err = db.PrepareContext(ctx, getAuthorizationCode); err != nil {
 		return nil, fmt.Errorf("error preparing query GetAuthorizationCode: %w", err)
 	}
@@ -86,6 +92,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.getOIDCSessionStmt, err = db.PrepareContext(ctx, getOIDCSession); err != nil {
 		return nil, fmt.Errorf("error preparing query GetOIDCSession: %w", err)
+	}
+	if q.getTOTPCredentialStmt, err = db.PrepareContext(ctx, getTOTPCredential); err != nil {
+		return nil, fmt.Errorf("error preparing query GetTOTPCredential: %w", err)
 	}
 	if q.getTokenByAccessTokenStmt, err = db.PrepareContext(ctx, getTokenByAccessToken); err != nil {
 		return nil, fmt.Errorf("error preparing query GetTokenByAccessToken: %w", err)
@@ -102,6 +111,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	if q.markAuthorizationCodeUsedStmt, err = db.PrepareContext(ctx, markAuthorizationCodeUsed); err != nil {
 		return nil, fmt.Errorf("error preparing query MarkAuthorizationCodeUsed: %w", err)
 	}
+	if q.touchTOTPCredentialStmt, err = db.PrepareContext(ctx, touchTOTPCredential); err != nil {
+		return nil, fmt.Errorf("error preparing query TouchTOTPCredential: %w", err)
+	}
 	if q.updateAuthorizationCodePKCEStmt, err = db.PrepareContext(ctx, updateAuthorizationCodePKCE); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateAuthorizationCodePKCE: %w", err)
 	}
@@ -110,6 +122,9 @@ func Prepare(ctx context.Context, db DBTX) (*Queries, error) {
 	}
 	if q.updateClientSecretStmt, err = db.PrepareContext(ctx, updateClientSecret); err != nil {
 		return nil, fmt.Errorf("error preparing query UpdateClientSecret: %w", err)
+	}
+	if q.upsertTOTPCredentialStmt, err = db.PrepareContext(ctx, upsertTOTPCredential); err != nil {
+		return nil, fmt.Errorf("error preparing query UpsertTOTPCredential: %w", err)
 	}
 	return &q, nil
 }
@@ -181,6 +196,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing deleteOIDCSessionStmt: %w", cerr)
 		}
 	}
+	if q.deleteTOTPCredentialStmt != nil {
+		if cerr := q.deleteTOTPCredentialStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing deleteTOTPCredentialStmt: %w", cerr)
+		}
+	}
 	if q.deleteTokenStmt != nil {
 		if cerr := q.deleteTokenStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing deleteTokenStmt: %w", cerr)
@@ -206,6 +226,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing deleteTokensByUserAndClientStmt: %w", cerr)
 		}
 	}
+	if q.enableTOTPCredentialStmt != nil {
+		if cerr := q.enableTOTPCredentialStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing enableTOTPCredentialStmt: %w", cerr)
+		}
+	}
 	if q.getAuthorizationCodeStmt != nil {
 		if cerr := q.getAuthorizationCodeStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getAuthorizationCodeStmt: %w", cerr)
@@ -219,6 +244,11 @@ func (q *Queries) Close() error {
 	if q.getOIDCSessionStmt != nil {
 		if cerr := q.getOIDCSessionStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing getOIDCSessionStmt: %w", cerr)
+		}
+	}
+	if q.getTOTPCredentialStmt != nil {
+		if cerr := q.getTOTPCredentialStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing getTOTPCredentialStmt: %w", cerr)
 		}
 	}
 	if q.getTokenByAccessTokenStmt != nil {
@@ -246,6 +276,11 @@ func (q *Queries) Close() error {
 			err = fmt.Errorf("error closing markAuthorizationCodeUsedStmt: %w", cerr)
 		}
 	}
+	if q.touchTOTPCredentialStmt != nil {
+		if cerr := q.touchTOTPCredentialStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing touchTOTPCredentialStmt: %w", cerr)
+		}
+	}
 	if q.updateAuthorizationCodePKCEStmt != nil {
 		if cerr := q.updateAuthorizationCodePKCEStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateAuthorizationCodePKCEStmt: %w", cerr)
@@ -259,6 +294,11 @@ func (q *Queries) Close() error {
 	if q.updateClientSecretStmt != nil {
 		if cerr := q.updateClientSecretStmt.Close(); cerr != nil {
 			err = fmt.Errorf("error closing updateClientSecretStmt: %w", cerr)
+		}
+	}
+	if q.upsertTOTPCredentialStmt != nil {
+		if cerr := q.upsertTOTPCredentialStmt.Close(); cerr != nil {
+			err = fmt.Errorf("error closing upsertTOTPCredentialStmt: %w", cerr)
 		}
 	}
 	return err
@@ -313,22 +353,27 @@ type Queries struct {
 	deleteExpiredAuthorizationCodesStmt *sql.Stmt
 	deleteExpiredTokensStmt             *sql.Stmt
 	deleteOIDCSessionStmt               *sql.Stmt
+	deleteTOTPCredentialStmt            *sql.Stmt
 	deleteTokenStmt                     *sql.Stmt
 	deleteTokenByAccessTokenStmt        *sql.Stmt
 	deleteTokenByRefreshTokenStmt       *sql.Stmt
 	deleteTokensByRequestIDStmt         *sql.Stmt
 	deleteTokensByUserAndClientStmt     *sql.Stmt
+	enableTOTPCredentialStmt            *sql.Stmt
 	getAuthorizationCodeStmt            *sql.Stmt
 	getClientStmt                       *sql.Stmt
 	getOIDCSessionStmt                  *sql.Stmt
+	getTOTPCredentialStmt               *sql.Stmt
 	getTokenByAccessTokenStmt           *sql.Stmt
 	getTokenByIDStmt                    *sql.Stmt
 	getTokenByRefreshTokenStmt          *sql.Stmt
 	listClientsStmt                     *sql.Stmt
 	markAuthorizationCodeUsedStmt       *sql.Stmt
+	touchTOTPCredentialStmt             *sql.Stmt
 	updateAuthorizationCodePKCEStmt     *sql.Stmt
 	updateClientStmt                    *sql.Stmt
 	updateClientSecretStmt              *sql.Stmt
+	upsertTOTPCredentialStmt            *sql.Stmt
 }
 
 func (q *Queries) WithTx(tx *sql.Tx) *Queries {
@@ -348,21 +393,26 @@ func (q *Queries) WithTx(tx *sql.Tx) *Queries {
 		deleteExpiredAuthorizationCodesStmt: q.deleteExpiredAuthorizationCodesStmt,
 		deleteExpiredTokensStmt:             q.deleteExpiredTokensStmt,
 		deleteOIDCSessionStmt:               q.deleteOIDCSessionStmt,
+		deleteTOTPCredentialStmt:            q.deleteTOTPCredentialStmt,
 		deleteTokenStmt:                     q.deleteTokenStmt,
 		deleteTokenByAccessTokenStmt:        q.deleteTokenByAccessTokenStmt,
 		deleteTokenByRefreshTokenStmt:       q.deleteTokenByRefreshTokenStmt,
 		deleteTokensByRequestIDStmt:         q.deleteTokensByRequestIDStmt,
 		deleteTokensByUserAndClientStmt:     q.deleteTokensByUserAndClientStmt,
+		enableTOTPCredentialStmt:            q.enableTOTPCredentialStmt,
 		getAuthorizationCodeStmt:            q.getAuthorizationCodeStmt,
 		getClientStmt:                       q.getClientStmt,
 		getOIDCSessionStmt:                  q.getOIDCSessionStmt,
+		getTOTPCredentialStmt:               q.getTOTPCredentialStmt,
 		getTokenByAccessTokenStmt:           q.getTokenByAccessTokenStmt,
 		getTokenByIDStmt:                    q.getTokenByIDStmt,
 		getTokenByRefreshTokenStmt:          q.getTokenByRefreshTokenStmt,
 		listClientsStmt:                     q.listClientsStmt,
 		markAuthorizationCodeUsedStmt:       q.markAuthorizationCodeUsedStmt,
+		touchTOTPCredentialStmt:             q.touchTOTPCredentialStmt,
 		updateAuthorizationCodePKCEStmt:     q.updateAuthorizationCodePKCEStmt,
 		updateClientStmt:                    q.updateClientStmt,
 		updateClientSecretStmt:              q.updateClientSecretStmt,
+		upsertTOTPCredentialStmt:            q.upsertTOTPCredentialStmt,
 	}
 }

--- a/internal/repository/oidc/models.go
+++ b/internal/repository/oidc/models.go
@@ -58,3 +58,11 @@ type Token struct {
 	ExpiresAt    time.Time      `json:"expires_at"`
 	CreatedAt    time.Time      `json:"created_at"`
 }
+
+type TotpCredential struct {
+	UserID     uuid.UUID    `json:"user_id"`
+	Secret     string       `json:"secret"`
+	Enabled    bool         `json:"enabled"`
+	CreatedAt  time.Time    `json:"created_at"`
+	LastUsedAt sql.NullTime `json:"last_used_at"`
+}

--- a/internal/repository/oidc/oidc.sql.go
+++ b/internal/repository/oidc/oidc.sql.go
@@ -246,6 +246,15 @@ func (q *Queries) DeleteOIDCSession(ctx context.Context, authorizeCode string) e
 	return err
 }
 
+const deleteTOTPCredential = `-- name: DeleteTOTPCredential :exec
+DELETE FROM totp_credentials WHERE user_id = $1
+`
+
+func (q *Queries) DeleteTOTPCredential(ctx context.Context, userID uuid.UUID) error {
+	_, err := q.exec(ctx, q.deleteTOTPCredentialStmt, deleteTOTPCredential, userID)
+	return err
+}
+
 const deleteToken = `-- name: DeleteToken :exec
 DELETE FROM tokens WHERE id = $1
 `
@@ -293,6 +302,16 @@ type DeleteTokensByUserAndClientParams struct {
 
 func (q *Queries) DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTokensByUserAndClientParams) error {
 	_, err := q.exec(ctx, q.deleteTokensByUserAndClientStmt, deleteTokensByUserAndClient, arg.UserID, arg.ClientID)
+	return err
+}
+
+const enableTOTPCredential = `-- name: EnableTOTPCredential :exec
+UPDATE totp_credentials SET enabled = TRUE, last_used_at = CURRENT_TIMESTAMP
+WHERE user_id = $1
+`
+
+func (q *Queries) EnableTOTPCredential(ctx context.Context, userID uuid.UUID) error {
+	_, err := q.exec(ctx, q.enableTOTPCredentialStmt, enableTOTPCredential, userID)
 	return err
 }
 
@@ -354,6 +373,23 @@ func (q *Queries) GetOIDCSession(ctx context.Context, authorizeCode string) (Oid
 		&i.AuthTime,
 		&i.RequestedAt,
 		&i.CreatedAt,
+	)
+	return i, err
+}
+
+const getTOTPCredential = `-- name: GetTOTPCredential :one
+SELECT user_id, secret, enabled, created_at, last_used_at FROM totp_credentials WHERE user_id = $1
+`
+
+func (q *Queries) GetTOTPCredential(ctx context.Context, userID uuid.UUID) (TotpCredential, error) {
+	row := q.queryRow(ctx, q.getTOTPCredentialStmt, getTOTPCredential, userID)
+	var i TotpCredential
+	err := row.Scan(
+		&i.UserID,
+		&i.Secret,
+		&i.Enabled,
+		&i.CreatedAt,
+		&i.LastUsedAt,
 	)
 	return i, err
 }
@@ -465,6 +501,16 @@ func (q *Queries) MarkAuthorizationCodeUsed(ctx context.Context, code string) er
 	return err
 }
 
+const touchTOTPCredential = `-- name: TouchTOTPCredential :exec
+UPDATE totp_credentials SET last_used_at = CURRENT_TIMESTAMP
+WHERE user_id = $1
+`
+
+func (q *Queries) TouchTOTPCredential(ctx context.Context, userID uuid.UUID) error {
+	_, err := q.exec(ctx, q.touchTOTPCredentialStmt, touchTOTPCredential, userID)
+	return err
+}
+
 const updateAuthorizationCodePKCE = `-- name: UpdateAuthorizationCodePKCE :exec
 UPDATE authorization_codes SET
     code_challenge = $1,
@@ -521,5 +567,31 @@ type UpdateClientSecretParams struct {
 
 func (q *Queries) UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error {
 	_, err := q.exec(ctx, q.updateClientSecretStmt, updateClientSecret, arg.ClientSecretHash, arg.ClientID)
+	return err
+}
+
+const upsertTOTPCredential = `-- name: UpsertTOTPCredential :exec
+
+INSERT INTO totp_credentials (user_id, secret, enabled)
+VALUES ($1, $2, $3)
+ON CONFLICT (user_id) DO UPDATE SET
+    secret = EXCLUDED.secret,
+    enabled = EXCLUDED.enabled,
+    created_at = CURRENT_TIMESTAMP,
+    last_used_at = NULL
+`
+
+type UpsertTOTPCredentialParams struct {
+	UserID  uuid.UUID `json:"user_id"`
+	Secret  string    `json:"secret"`
+	Enabled bool      `json:"enabled"`
+}
+
+// TOTP queries
+// Insert a new secret or replace the existing one when the user re-enrols.
+// enabled stays at the supplied value so we can distinguish "secret stored,
+// waiting for first verification" from "secret in active use".
+func (q *Queries) UpsertTOTPCredential(ctx context.Context, arg UpsertTOTPCredentialParams) error {
+	_, err := q.exec(ctx, q.upsertTOTPCredentialStmt, upsertTOTPCredential, arg.UserID, arg.Secret, arg.Enabled)
 	return err
 }

--- a/internal/repository/oidc/querier.go
+++ b/internal/repository/oidc/querier.go
@@ -29,22 +29,31 @@ type Querier interface {
 	DeleteExpiredAuthorizationCodes(ctx context.Context) error
 	DeleteExpiredTokens(ctx context.Context) error
 	DeleteOIDCSession(ctx context.Context, authorizeCode string) error
+	DeleteTOTPCredential(ctx context.Context, userID uuid.UUID) error
 	DeleteToken(ctx context.Context, id uuid.UUID) error
 	DeleteTokenByAccessToken(ctx context.Context, accessToken string) error
 	DeleteTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) error
 	DeleteTokensByRequestID(ctx context.Context, requestID string) error
 	DeleteTokensByUserAndClient(ctx context.Context, arg DeleteTokensByUserAndClientParams) error
+	EnableTOTPCredential(ctx context.Context, userID uuid.UUID) error
 	GetAuthorizationCode(ctx context.Context, code string) (AuthorizationCode, error)
 	GetClient(ctx context.Context, clientID uuid.UUID) (Client, error)
 	GetOIDCSession(ctx context.Context, authorizeCode string) (OidcSession, error)
+	GetTOTPCredential(ctx context.Context, userID uuid.UUID) (TotpCredential, error)
 	GetTokenByAccessToken(ctx context.Context, accessToken string) (Token, error)
 	GetTokenByID(ctx context.Context, id uuid.UUID) (Token, error)
 	GetTokenByRefreshToken(ctx context.Context, refreshToken sql.NullString) (Token, error)
 	ListClients(ctx context.Context) ([]Client, error)
 	MarkAuthorizationCodeUsed(ctx context.Context, code string) error
+	TouchTOTPCredential(ctx context.Context, userID uuid.UUID) error
 	UpdateAuthorizationCodePKCE(ctx context.Context, arg UpdateAuthorizationCodePKCEParams) error
 	UpdateClient(ctx context.Context, arg UpdateClientParams) error
 	UpdateClientSecret(ctx context.Context, arg UpdateClientSecretParams) error
+	// TOTP queries
+	// Insert a new secret or replace the existing one when the user re-enrols.
+	// enabled stays at the supplied value so we can distinguish "secret stored,
+	// waiting for first verification" from "secret in active use".
+	UpsertTOTPCredential(ctx context.Context, arg UpsertTOTPCredentialParams) error
 }
 
 var _ Querier = (*Queries)(nil)

--- a/internal/repository/totp.go
+++ b/internal/repository/totp.go
@@ -1,0 +1,70 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/google/uuid"
+
+	"github.com/traPtitech/portal-oidc/internal/domain"
+	"github.com/traPtitech/portal-oidc/internal/repository/oidc"
+)
+
+var ErrTOTPCredentialNotFound = errors.New("TOTP credential not found")
+
+type TOTPCredentialRepository interface {
+	Upsert(ctx context.Context, userID uuid.UUID, secret string, enabled bool) error
+	Get(ctx context.Context, userID uuid.UUID) (domain.TOTPCredential, error)
+	Enable(ctx context.Context, userID uuid.UUID) error
+	Touch(ctx context.Context, userID uuid.UUID) error
+	Delete(ctx context.Context, userID uuid.UUID) error
+}
+
+type totpCredentialRepository struct {
+	queries *oidc.Queries
+}
+
+func NewTOTPCredentialRepository(queries *oidc.Queries) TOTPCredentialRepository {
+	return &totpCredentialRepository{queries: queries}
+}
+
+func (r *totpCredentialRepository) Upsert(ctx context.Context, userID uuid.UUID, secret string, enabled bool) error {
+	return r.queries.UpsertTOTPCredential(ctx, oidc.UpsertTOTPCredentialParams{
+		UserID:  userID,
+		Secret:  secret,
+		Enabled: enabled,
+	})
+}
+
+func (r *totpCredentialRepository) Get(ctx context.Context, userID uuid.UUID) (domain.TOTPCredential, error) {
+	row, err := r.queries.GetTOTPCredential(ctx, userID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return domain.TOTPCredential{}, ErrTOTPCredentialNotFound
+		}
+		return domain.TOTPCredential{}, err
+	}
+	c := domain.TOTPCredential{
+		UserID:    row.UserID,
+		Secret:    row.Secret,
+		Enabled:   row.Enabled,
+		CreatedAt: row.CreatedAt,
+	}
+	if row.LastUsedAt.Valid {
+		c.LastUsedAt = &row.LastUsedAt.Time
+	}
+	return c, nil
+}
+
+func (r *totpCredentialRepository) Enable(ctx context.Context, userID uuid.UUID) error {
+	return r.queries.EnableTOTPCredential(ctx, userID)
+}
+
+func (r *totpCredentialRepository) Touch(ctx context.Context, userID uuid.UUID) error {
+	return r.queries.TouchTOTPCredential(ctx, userID)
+}
+
+func (r *totpCredentialRepository) Delete(ctx context.Context, userID uuid.UUID) error {
+	return r.queries.DeleteTOTPCredential(ctx, userID)
+}

--- a/internal/router/v1/client_test.go
+++ b/internal/router/v1/client_test.go
@@ -179,7 +179,9 @@ func setupTestHandler(t *testing.T) (*Handler, func()) {
 		compose.OAuth2TokenRevocationFactory,
 	)
 
-	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, OAuthConfig{
+	totpRepo := repository.NewTOTPCredentialRepository(queries)
+
+	handler := NewHandler(clientUseCase, oauthUsecase, oauth2Provider, nil, totpRepo, OAuthConfig{
 		Issuer:      "http://localhost:8080",
 		Environment: "development",
 		TestUserID:  "00000000-0000-0000-0000-000000000000",

--- a/internal/router/v1/handler.go
+++ b/internal/router/v1/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/ory/fosite"
 
+	"github.com/traPtitech/portal-oidc/internal/repository"
 	"github.com/traPtitech/portal-oidc/internal/usecase"
 )
 
@@ -16,6 +17,7 @@ type Handler struct {
 	oauthUseCase  usecase.OAuthUseCase
 	oauth2        fosite.OAuth2Provider
 	userUseCase   usecase.UserUseCase
+	totpCreds     repository.TOTPCredentialRepository
 	sessions      *sessions.CookieStore
 	config        OAuthConfig
 }
@@ -33,6 +35,7 @@ func NewHandler(
 	oauthUseCase usecase.OAuthUseCase,
 	oauth2 fosite.OAuth2Provider,
 	userUseCase usecase.UserUseCase,
+	totpCreds repository.TOTPCredentialRepository,
 	config OAuthConfig,
 ) *Handler {
 	store := sessions.NewCookieStore(config.SessionSecret)
@@ -49,6 +52,7 @@ func NewHandler(
 		oauthUseCase:  oauthUseCase,
 		oauth2:        oauth2,
 		userUseCase:   userUseCase,
+		totpCreds:     totpCreds,
 		sessions:      store,
 		config:        config,
 	}

--- a/internal/router/v1/totp.go
+++ b/internal/router/v1/totp.go
@@ -1,0 +1,192 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v5"
+	"github.com/pquerna/otp/totp"
+
+	"github.com/traPtitech/portal-oidc/internal/repository"
+)
+
+const totpIssuer = "traPortal"
+
+// RegisterTOTP starts TOTP enrolment for the logged-in user. The generated
+// secret is stored with enabled=false so a half-finished enrolment cannot
+// gate subsequent logins. The response contains the otpauth:// URI plus the
+// raw secret in case the client wants to display a manual entry option.
+//
+// Refs:
+//   - RFC 6238 §3 (TOTP algorithm requires a successful verification before
+//     accepting the seed for authentication)
+//     https://datatracker.ietf.org/doc/html/rfc6238#section-3
+func (h *Handler) RegisterTOTP(ctx *echo.Context) error {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+
+	key, err := totp.Generate(totp.GenerateOpts{
+		Issuer:      totpIssuer,
+		AccountName: info.UserID,
+	})
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	if err := h.totpCreds.Upsert(ctx.Request().Context(), userID, key.Secret(), false); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	return ctx.JSON(http.StatusOK, map[string]any{
+		"otpauth_url": key.URL(),
+		"secret":      key.Secret(),
+	})
+}
+
+// VerifyTOTPRegistration accepts the first OTP from the user and, on success,
+// flips the credential to enabled. RFC 6238 §3 requires this round-trip
+// before the OP can rely on the seed.
+func (h *Handler) VerifyTOTPRegistration(ctx *echo.Context) error {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	code, err := readTOTPCode(ctx)
+	if err != nil {
+		return err
+	}
+
+	cred, err := h.totpCreds.Get(ctx.Request().Context(), userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrTOTPCredentialNotFound) {
+			return echo.NewHTTPError(http.StatusBadRequest, "no pending TOTP enrolment")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+
+	if !totp.Validate(code, cred.Secret) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid code")
+	}
+	if err := h.totpCreds.Enable(ctx.Request().Context(), userID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// LoginTOTP verifies a TOTP code as a second factor during login. The caller
+// must already be logged in via primary authentication; the endpoint touches
+// last_used_at on success but does not yet integrate with the AMR claim
+// (Phase 5.3 will do that).
+func (h *Handler) LoginTOTP(ctx *echo.Context) error {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "primary authentication required")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	code, err := readTOTPCode(ctx)
+	if err != nil {
+		return err
+	}
+
+	cred, err := h.totpCreds.Get(ctx.Request().Context(), userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrTOTPCredentialNotFound) {
+			return echo.NewHTTPError(http.StatusBadRequest, "TOTP not enrolled")
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	if !cred.Enabled {
+		return echo.NewHTTPError(http.StatusBadRequest, "TOTP enrolment incomplete")
+	}
+	if !totp.Validate(code, cred.Secret) {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid code")
+	}
+	if err := h.totpCreds.Touch(ctx.Request().Context(), userID); err != nil {
+		// Best-effort timestamp update; failure does not invalidate the auth.
+		_ = err
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+// GetTOTPStatus reports whether the caller has a usable TOTP credential.
+func (h *Handler) GetTOTPStatus(ctx *echo.Context) error {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	cred, err := h.totpCreds.Get(ctx.Request().Context(), userID)
+	if err != nil {
+		if errors.Is(err, repository.ErrTOTPCredentialNotFound) {
+			return ctx.JSON(http.StatusOK, map[string]any{"enrolled": false})
+		}
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	out := map[string]any{
+		"enrolled": true,
+		"enabled":  cred.Enabled,
+	}
+	if cred.LastUsedAt != nil {
+		out["last_used_at"] = cred.LastUsedAt.Unix()
+	}
+	return ctx.JSON(http.StatusOK, out)
+}
+
+// DisableTOTP removes the user's TOTP credential entirely.
+func (h *Handler) DisableTOTP(ctx *echo.Context) error {
+	info, ok := h.getAuthInfo(ctx)
+	if !ok {
+		return echo.NewHTTPError(http.StatusUnauthorized, "not logged in")
+	}
+	userID, err := uuid.Parse(info.UserID)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusUnauthorized, "invalid session subject")
+	}
+	if err := h.totpCreds.Delete(ctx.Request().Context(), userID); err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+	}
+	return ctx.NoContent(http.StatusNoContent)
+}
+
+func readTOTPCode(ctx *echo.Context) (string, error) {
+	var body struct {
+		Code string `json:"code"`
+	}
+	if ctx.Request().Header.Get("Content-Type") == "application/json" {
+		if err := json.NewDecoder(ctx.Request().Body).Decode(&body); err != nil {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+		}
+	} else {
+		if err := ctx.Request().ParseForm(); err != nil {
+			return "", echo.NewHTTPError(http.StatusBadRequest, "invalid body")
+		}
+		body.Code = ctx.Request().Form.Get("code")
+	}
+	if body.Code == "" {
+		return "", echo.NewHTTPError(http.StatusBadRequest, "code required")
+	}
+	return body.Code, nil
+}
+
+// _ keeps net/url imported if a future code path needs to URL-encode the
+// otpauth response field.
+var _ = url.QueryEscape


### PR DESCRIPTION
## 概要

RFC 6238 TOTP を実装。pquerna/otp ベースで 5 エンドポイント (\`/auth/totp/*\`) と \`totp_credentials\` テーブルを追加。

## エンドポイント

| メソッド | パス | 用途 |
|---|---|---|
| POST | \`/auth/totp/register\` | 登録開始 (otpauth URL + secret 返却) |
| POST | \`/auth/totp/register/verify\` | 初回 OTP 検証 → enabled 化 |
| POST | \`/auth/totp/login\` | ログイン時の second factor 検証 |
| GET | \`/auth/totp\` | 登録状態取得 |
| DELETE | \`/auth/totp\` | 削除 |

## 変更

- \`db/schema.sql\`: \`totp_credentials\` テーブル (user_id PK, secret, enabled, created_at, last_used_at)
- \`db/query/oidc.sql\`: Upsert/Get/Enable/Touch/Delete + ON CONFLICT で再登録対応
- \`internal/domain/totp.go\`: \`TOTPCredential\` 構造体
- \`internal/repository/totp.go\`: \`TOTPCredentialRepository\` 実装
- \`internal/router/v1/totp.go\` (新規): 5 ハンドラ
- \`cmd/serve.go\`: ルート登録 + repo 注入
- 新規 dep: \`github.com/pquerna/otp v1.5.0\`

## セキュリティ姿勢

- \`enabled\` は最初の OTP 検証成功後のみ true に。半端な登録ではログインを塞がない (RFC 6238 §3 準拠)
- secret は **平文 DB 保存**。仕様 §シークレット管理にあるユーザ別暗号化鍵での保護は follow-up PR
- マルチステップログイン (パスワード後に TOTP 必須) のオーケストレーションは別 PR
- AMR \`"otp"\` を ID Token に含める統合は Phase 5.3 で

## RFC / 仕様根拠

| 項目 | RFC | 該当 |
|---|---|---|
| TOTP アルゴリズム | RFC 6238 | [§3](https://datatracker.ietf.org/doc/html/rfc6238#section-3) |
| HOTP (TOTP 基底) | RFC 4226 | [全文](https://datatracker.ietf.org/doc/html/rfc4226) |
| traPortal v2 仕様 | §認証 (TOTP endpoints) | |

## テスト

- [ ] CI (Lint / Build / Test / Conformance Suite / Security Scan) パス
- [ ] \`go build ./...\` / \`golangci-lint run\` / \`gosec\` 0 issues (確認済み)
- [ ] 手動: register → otpauth URL を Google Authenticator 等で読み込み → register/verify で enabled
- [ ] 手動: 別 OTP で /auth/totp/login が 204、不正 OTP で 401