### PR TITLE
feat(oauth): ID Token に acr / amr claim を出力 (OIDC Core 1.0 §2 / RFC 8176)

### DIFF
--- a/internal/repository/oauth/session.go
+++ b/internal/repository/oauth/session.go
@@ -37,6 +37,18 @@ func NewSession(subject string, authTime time.Time) *Session {
 	}
 }
 
+func (s *Session) SetAuthenticationContext(acr string, amr []string) {
+	if s.idTokenClaims == nil {
+		s.idTokenClaims = &jwt.IDTokenClaims{Subject: s.subject}
+	}
+	s.idTokenClaims.AuthenticationContextClassReference = acr
+	if len(amr) > 0 {
+		copied := make([]string, len(amr))
+		copy(copied, amr)
+		s.idTokenClaims.AuthenticationMethodsReferences = copied
+	}
+}
+
 func (s *Session) SetExpiresAt(key fosite.TokenType, exp time.Time) {
 	if s.expiresAt == nil {
 		s.expiresAt = make(map[fosite.TokenType]time.Time)

--- a/internal/router/v1/auth.go
+++ b/internal/router/v1/auth.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"encoding/gob"
 	"errors"
 	"html"
 	"net/http"
@@ -14,6 +15,10 @@ import (
 )
 
 const sessionName = "oidc_session"
+
+func init() {
+	gob.Register([]string{})
+}
 
 func (h *Handler) GetLogin(ctx *echo.Context) error {
 	returnURL := sanitizeReturnURL(ctx.QueryParam("return_url"))
@@ -84,6 +89,7 @@ func (h *Handler) PostLogin(ctx *echo.Context) error {
 	session.Values["user_id"] = userID
 	session.Values["authenticated"] = true
 	session.Values["auth_time"] = time.Now().Unix()
+	session.Values["amr"] = []string{"pwd"}
 
 	if err := session.Save(ctx.Request(), ctx.Response()); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to save session")
@@ -144,6 +150,8 @@ func sanitizeReturnURL(raw string) string {
 type authInfo struct {
 	UserID   string
 	AuthTime time.Time
+	AMR      []string
+	ACR      string
 }
 
 func (h *Handler) getAuthInfo(ctx *echo.Context) (authInfo, bool) {
@@ -167,5 +175,8 @@ func (h *Handler) getAuthInfo(ctx *echo.Context) (authInfo, bool) {
 		at = time.Unix(authTimeSec, 0)
 	}
 
-	return authInfo{UserID: userID, AuthTime: at}, true
+	amr, _ := session.Values["amr"].([]string) //nolint:errcheck
+	acr, _ := session.Values["acr"].(string)   //nolint:errcheck
+
+	return authInfo{UserID: userID, AuthTime: at, AMR: amr, ACR: acr}, true
 }

--- a/internal/router/v1/oauth.go
+++ b/internal/router/v1/oauth.go
@@ -72,19 +72,25 @@ func (h *Handler) authorize(ctx *echo.Context) error {
 
 	userID := info.UserID
 	authTime := info.AuthTime
+	amr := info.AMR
+	acr := info.ACR
 	if h.config.Environment != "production" {
 		userID = h.config.TestUserID
 		authTime = time.Now()
+		if len(amr) == 0 {
+			amr = []string{"pwd"}
+		}
 	}
 
-	return h.completeAuthorize(ctx, ar, userID, authTime)
+	return h.completeAuthorize(ctx, ar, userID, authTime, acr, amr)
 }
 
-func (h *Handler) completeAuthorize(ctx *echo.Context, ar fosite.AuthorizeRequester, userID string, authTime time.Time) error {
+func (h *Handler) completeAuthorize(ctx *echo.Context, ar fosite.AuthorizeRequester, userID string, authTime time.Time, acr string, amr []string) error {
 	c := ctx.Request().Context()
 	rw := ctx.Response()
 
 	session := oauth.NewSession(userID, authTime)
+	session.SetAuthenticationContext(acr, amr)
 	for _, scope := range ar.GetRequestedScopes() {
 		ar.GrantScope(scope)
 	}


### PR DESCRIPTION
## 概要
- パスワードログイン時、cookie session に `amr=["pwd"]` を保存する。
- `getAuthInfo` で `amr` / `acr` を読み戻し、`completeAuthorize` を経由して fosite session に渡す。
- 新規メソッド `Session.SetAuthenticationContext` で `idTokenClaims` に値を書き込み、ID Token に両 claim が乗るようにする。

## 背景
[OpenID Connect Core 1.0 §2](https://openid.net/specs/openid-connect-core-1_0.html#IDToken) の optional claim である `acr` / `amr` を未実装だった。RP は「ユーザーがどう認証されたか」を判別できず、どの ID Token も同じに見える状態になっていた。WebAuthn / TOTP (後続 PR) はこの cookie session の `amr` に値を追加するだけで済むようになる。

## 仕様参照
- [OpenID Connect Core 1.0 §2 — ID Token](https://openid.net/specs/openid-connect-core-1_0.html#IDToken)
- [RFC 8176 — Authentication Method Reference Values](https://www.rfc-editor.org/rfc/rfc8176.html) (`pwd`, `otp`, `hwk`, …)

## レビュアー向けメモ
- `gob.Register([]string{})` を入れている理由: gorilla/sessions が `session.Values` (`map[interface{}]interface{}`) を `encoding/gob` で encode するため、具象型を register しないと save 時に panic する。
- 非本番環境の auto-login では `amr=["pwd"]` を入れる。テスト用ログインフォーム経由で入力した場合と挙動を揃えるためで、別の値を入れて意図せず差分が出ないようにしている。

## 後続 (本 PR では実装しない)
- WebAuthn / TOTP の 2FA 完了時に `session.Values["amr"]` へ `"hwk"` / `"otp"` を追加する。
- factor 数に応じた `acr` (例: 単一要素は `"0"`, MFA は `"1"`) の policy を決めて反映する。

## 確認項目
- [ ] CI green (build / lint / unit tests)。
- [ ] Manual: login → authorize → ID Token を decode し、`amr: ["pwd"]` が含まれること。
- [ ] Conformance suite が引き続き green であること。