### PR TITLE
feat(server): SIGINT / SIGTERM で graceful shutdown

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"log"
 	"net/http"
 	"os"
+	"os/signal"
+	"syscall"
 	"time"
 
 	"github.com/alecthomas/kong"
 )
+
+const shutdownTimeout = 30 * time.Second
 
 type CLI struct {
 	Config string   `short:"c" help:"Config file path" type:"path"`
@@ -27,8 +33,33 @@ func (s *ServeCmd) Run(cfg *Config) error {
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 	}
-	log.Printf("Starting server on %s", srv.Addr)
-	return srv.ListenAndServe()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		log.Printf("Starting server on %s", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+			return
+		}
+		serveErr <- nil
+	}()
+
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+
+	select {
+	case err := <-serveErr:
+		return err
+	case sig := <-signals:
+		log.Printf("Received %s, shutting down...", sig)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return err
+	}
+	return <-serveErr
 }
 
 func main() {


### PR DESCRIPTION
## 概要
- HTTP listener を別 goroutine で起動し、SIGINT / SIGTERM を待ち受ける。
- signal を受け取ったら `srv.Shutdown` を 30 秒の deadline 付きで呼び、処理中のリクエストが完了するのを待ってから終了する。
- `http.ErrServerClosed` は正常終了として扱い、graceful shutdown が完了したときは nil を返す。

## 背景
現状は `ListenAndServe` が永久にブロックして signal を無視するので、Kubernetes の Pod 終了時に SIGTERM を受けてもプロセスがリクエスト処理中に強制終了される。token endpoint への POST や DB トランザクションが途中で切れ、行が中途半端な状態で残る可能性がある。標準の `net/http` graceful shutdown パターンで、依存追加なしに対処できる。

## レビュアー向けメモ
- 30 秒は K8s default の `terminationGracePeriodSeconds` に揃えた。これを超えて処理中のリクエストは Go の HTTP server が強制 close する。
- DB connection は明示的に close していない。`*sql.DB` は finalizer がプロセス終了時に閉じるし、pool は全 repo で共有しているので、明示 close するには DB handle を `newServer` から外に出す必要がある。これはより大きな refactor になるので follow-up に回す。

## 確認項目
- [ ] CI green。
- [ ] Manual: `./portal-oidc serve` を起動し、`curl -X POST localhost:8080/oauth2/token ...` を実行している間に `kill -TERM <pid>`。リクエストが完了し、ログに "Received terminated, shutting down..." が出ること。