### PR TITLE
feat(server): /ready エンドポイント追加 (DB ping によるreadiness probe)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/labstack/echo/v5"
@@ -87,6 +88,17 @@ func newServer(cfg Config) (http.Handler, error) {
 	e.GET("/logout", handler.Logout)
 	e.GET("/health", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
+	})
+	e.GET("/ready", func(c *echo.Context) error {
+		pingCtx, cancel := context.WithTimeout(c.Request().Context(), 2*time.Second)
+		defer cancel()
+		if err := oidcDB.PingContext(pingCtx); err != nil {
+			return c.JSON(http.StatusServiceUnavailable, map[string]string{
+				"status": "unavailable",
+				"reason": "oidc database unreachable",
+			})
+		}
+		return c.JSON(http.StatusOK, map[string]string{"status": "ready"})
 	})
 
 	return e, nil


### PR DESCRIPTION
## 概要
- `/health` は pure liveness probe のまま (`{"status":"ok"}` を返すだけ)。
- `/ready` を新設。OIDC database に 2 秒 timeout で ping し、失敗時は 503 を返す。

## 背景
現在 `/health` だけで、DB が落ちていても 200 を返す。これでは Kubernetes の liveness/readiness probe を当てても「プロセスが生きている」と「OAuth request を捌ける」が区別できない。K8s の標準パターンに沿って 2 つに分けた:
- `livenessProbe` → `/health` → プロセスが固まったら pod を再起動。
- `readinessProbe` → `/ready` → DB が落ちている pod を Service から外し、token endpoint で 5xx を返さないようにする。

## 確認項目
- [ ] CI green。
- [ ] Manual: DB up 状態で `curl localhost:8080/ready` → 200 `{"status":"ready"}`。
- [ ] Manual: DB を停止 → `curl localhost:8080/ready` → 503 `{"status":"unavailable", ...}`。