### PR TITLE
feat(server): structured access log + X-Request-ID middleware 追加

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"time"
@@ -32,6 +33,8 @@ func (s *ServeCmd) Run(cfg *Config) error {
 }
 
 func main() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))
+
 	var cli CLI
 	parser := kong.Must(&cli,
 		kong.Name("portal-oidc"),

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -75,12 +76,7 @@ func newServer(cfg Config) (http.Handler, error) {
 	)
 
 	e := echo.New()
-	e.Use(middleware.Recover())
-	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins: []string{"*"},
-		AllowHeaders: []string{"*"},
-		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-	}))
+	registerMiddleware(e)
 	gen.RegisterHandlers(e, handler)
 	e.GET("/login", handler.GetLogin)
 	e.POST("/login", handler.PostLogin)
@@ -90,6 +86,42 @@ func newServer(cfg Config) (http.Handler, error) {
 	})
 
 	return e, nil
+}
+
+func registerMiddleware(e *echo.Echo) {
+	e.Use(middleware.Recover())
+	e.Use(middleware.RequestID())
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		LogMethod:    true,
+		LogURIPath:   true,
+		LogStatus:    true,
+		LogLatency:   true,
+		LogRemoteIP:  true,
+		LogRequestID: true,
+		LogValuesFunc: func(_ *echo.Context, v middleware.RequestLoggerValues) error {
+			level := slog.LevelInfo
+			switch {
+			case v.Status >= 500:
+				level = slog.LevelError
+			case v.Status >= 400:
+				level = slog.LevelWarn
+			}
+			slog.LogAttrs(context.Background(), level, "http_request",
+				slog.String("request_id", v.RequestID),
+				slog.String("method", v.Method),
+				slog.String("path", v.URIPath),
+				slog.Int("status", v.Status),
+				slog.Duration("latency", v.Latency),
+				slog.String("remote_ip", v.RemoteIP),
+			)
+			return nil
+		},
+	}))
+	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
+		AllowOrigins: []string{"*"},
+		AllowHeaders: []string{"*"},
+		AllowMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+	}))
 }
 
 func postgresDSN(cfg DatabaseConfig) string {


### PR DESCRIPTION
## 概要
- Echo の `RequestID` middleware を追加。リクエストごとに `X-Request-ID` を付与する（受信ヘッダがあればその値を使い、無ければ生成する）。
- Echo の `RequestLogger` を JSON `slog` handler に接続し、リクエスト 1 件あたり 1 行のログを出力する。フィールドは `request_id`, `method`, `path`, `status`, `latency`, `remote_ip`。
- `status >= 500` を `error`、`400-499` を `warn`、それ以外を `info` に対応付け、ログレベルベースのアラートをそのまま設定できるようにした。
- `main` で global slog handler を JSON / stdout に設定する。

## 背景
現在 access log が一切出ておらず、起動行しか残らない。500 が起きたかどうか、各リクエストがどれだけかかったか、どの RP がどの endpoint を叩いているかが分からない。構造化 JSON で出せばログ転送先で全フィールドが index でき、`request_id` を辿れば 1 つの OAuth フロー (login → authorize → token → userinfo) を相関できる。

## レビュアー向けメモ
- middleware の順序: `Recover` を先頭（logger middleware 自体が panic しても recover できるように）→ `RequestID`（後段が header を見られるように）→ `RequestLogger` → `CORS`。
- `newServer` が funlen を超えたので middleware 設定を `registerMiddleware` に切り出した。
- /health と /ready の skipper は意図的に入れていない。流量は低く、probe が叩けているか自体を ops が確認したいケースもあるため。

## 確認項目
- [ ] CI green。
- [ ] Manual: `curl -H 'X-Request-ID: foo' localhost:8080/health` → ログ行に `request_id=foo` が出ること。
- [ ] Manual: `curl -X POST localhost:8080/oauth2/token` を不正な body で叩く → ログ行が `status=400`、level `warn` で出ること。