### PR TITLE
feat(server): security ヘッダー追加 + 1MB body limit

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/labstack/echo/v5"
@@ -76,6 +77,8 @@ func newServer(cfg Config) (http.Handler, error) {
 
 	e := echo.New()
 	e.Use(middleware.Recover())
+	e.Use(middleware.BodyLimit(1 * middleware.MB))
+	e.Use(middleware.SecureWithConfig(secureConfig(cfg.Host)))
 	e.Use(middleware.CORSWithConfig(middleware.CORSConfig{
 		AllowOrigins: []string{"*"},
 		AllowHeaders: []string{"*"},
@@ -90,6 +93,19 @@ func newServer(cfg Config) (http.Handler, error) {
 	})
 
 	return e, nil
+}
+
+func secureConfig(host string) middleware.SecureConfig {
+	cfg := middleware.SecureConfig{
+		XSSProtection:      "1; mode=block",
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "DENY",
+		ReferrerPolicy:     "no-referrer",
+	}
+	if strings.HasPrefix(host, "https://") {
+		cfg.HSTSMaxAge = 31536000
+	}
+	return cfg
 }
 
 func postgresDSN(cfg DatabaseConfig) string {


### PR DESCRIPTION
## 概要
- `echo middleware.Secure` で以下のレスポンスヘッダを付与する:
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY` — login form を iframe に埋め込めないようにする (clickjacking 対策)。
  - `X-XSS-Protection: 1; mode=block`
  - `Referrer-Policy: no-referrer` — `code=` を含む URL を上流サイトに漏らさないため。
  - `Strict-Transport-Security: max-age=31536000` (issuer が https:// のときのみ)。
- `echo middleware.BodyLimit(1MB)` を追加。リクエスト body が上限を超えた場合はハンドラに到達する前に 413 を返す。

## 背景
現状 middleware は `Recover` + `CORS` のみ。ブラウザが `/login` を iframe に埋め込んでフォーム入力を奪うことが可能で、また 100MB の POST が `/oauth2/token` に来た場合 fosite が parse する前にメモリへ全量読み込まれる。

## レビュアー向けメモ
- HSTS は https issuer のときだけ付与する。HTTP 経由で送ると無効、かつ後から HTTPS に切り替える際に害になる。
- 1MB は十分余裕がある。OAuth body は通常 2KB 未満で、最大の正当な body である DCR の JWKS upload も問題なく収まる。
- CSP は本 PR では入れていない。login HTML が inline `<style>` を持っているため、CSP を正しく設定するには nonce 化か static file への分離が必要で、別 PR として切り出す。

## 確認項目
- [ ] CI green。
- [ ] Manual: `curl -I localhost:8080/health` → ヘッダに `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff` が含まれること。
- [ ] Manual: `curl -X POST -d "$(yes a | head -c 2000000)" localhost:8080/oauth2/token` → 413 が返ること。