### PR TITLE
feat(db): connection pool 設定 (max_open=25, max_idle=5, lifetime=30m)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/labstack/echo/v5"
@@ -109,11 +110,26 @@ func postgresDSN(cfg DatabaseConfig) string {
 	return u.String()
 }
 
+const (
+	dbMaxOpenConns    = 25
+	dbMaxIdleConns    = 5
+	dbConnMaxLifetime = 30 * time.Minute
+	dbConnMaxIdleTime = 5 * time.Minute
+)
+
+func tunePool(db *sql.DB) {
+	db.SetMaxOpenConns(dbMaxOpenConns)
+	db.SetMaxIdleConns(dbMaxIdleConns)
+	db.SetConnMaxLifetime(dbConnMaxLifetime)
+	db.SetConnMaxIdleTime(dbConnMaxIdleTime)
+}
+
 func setupOIDCDatabase(cfg DatabaseConfig) (*sql.DB, *oidc.Queries, error) {
 	db, err := sql.Open("pgx", postgresDSN(cfg))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open oidc database: %w", err)
 	}
+	tunePool(db)
 
 	if err := db.PingContext(context.Background()); err != nil {
 		return nil, nil, fmt.Errorf("failed to ping oidc database: %w", err)
@@ -132,6 +148,7 @@ func setupPortalDatabase(cfg DatabaseConfig) (*portal.Queries, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open portal database: %w", err)
 	}
+	tunePool(db)
 
 	if err := db.PingContext(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to ping portal database: %w", err)


### PR DESCRIPTION
## 概要
両方の `sql.DB` に pool 上限を設定する:
- `MaxOpenConns`: 25
- `MaxIdleConns`: 5
- `ConnMaxLifetime`: 30 min
- `ConnMaxIdleTime`: 5 min

## 背景
default `*sql.DB` は `MaxOpenConns = 0` (無制限)。トラフィック急増や slow query があった場合に接続数が際限なく増え、Postgres の `max_connections` (default 100) を使い切って同居サービスの接続まで弾いてしまう恐れがある。lifetime 上限を設定しておけば定期的に再接続が走るため、Postgres 再起動や DNS rotation 後の stale connection を保持し続けることもなくなる。

## レビュアー向けメモ
- 25 conn × pod 数 が `max_connections` 内に収まる必要がある。現状は 1 pod なので余裕がある。
- 値は const に固定している。env ごとに変えたくなった場合は `DatabaseConfig` に持ち上げるが、本 PR では機械的な適用に留め、設定可能化は follow-up に回す。

## 確認項目
- [ ] CI green。
- [ ] Manual: 起動中の pod から `pg_stat_activity` を見て、本サービスからの接続が 25 以下に収まっていること。