### PR TITLE
fix(auth): return_url の schemes / opaque / backslash を拒否

### DIFF
--- a/internal/router/v1/auth.go
+++ b/internal/router/v1/auth.go
@@ -131,11 +131,14 @@ func (h *Handler) Logout(ctx *echo.Context) error {
 }
 
 func sanitizeReturnURL(raw string) string {
-	if raw == "" {
+	if raw == "" || !strings.HasPrefix(raw, "/") {
+		return "/"
+	}
+	if strings.HasPrefix(raw, "//") || strings.HasPrefix(raw, "/\\") {
 		return "/"
 	}
 	parsed, err := url.Parse(raw)
-	if err != nil || parsed.Host != "" || strings.HasPrefix(raw, "//") {
+	if err != nil || parsed.Scheme != "" || parsed.Host != "" || parsed.Opaque != "" {
 		return "/"
 	}
 	return parsed.RequestURI()

--- a/internal/router/v1/auth_test.go
+++ b/internal/router/v1/auth_test.go
@@ -1,0 +1,31 @@
+package v1
+
+import "testing"
+
+func TestSanitizeReturnURL(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "/"},
+		{"root", "/", "/"},
+		{"path", "/oauth2/authorize", "/oauth2/authorize"},
+		{"path with query", "/oauth2/authorize?foo=bar", "/oauth2/authorize?foo=bar"},
+		{"protocol relative", "//evil.com/x", "/"},
+		{"absolute http", "http://evil.com/x", "/"},
+		{"absolute https", "https://evil.com/x", "/"},
+		{"javascript scheme", "javascript:alert(1)", "/"},
+		{"backslash", "/\\evil.com", "/"},
+		{"bare relative", "foo", "/"},
+		{"opaque", "mailto:a@b.c", "/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeReturnURL(tc.in)
+			if got != tc.want {
+				t.Errorf("sanitizeReturnURL(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
- `return_url` は単一の `/` で始まる文字列のみ許可し、`//` や `/\` は拒否する。
- さらに `Scheme` / `Host` / `Opaque` のいずれかが non-empty な URL も拒否対象とする。これで `javascript:alert(1)` や `mailto:...` も通らなくなる。
- 悪意ある入力パターンを網羅した table-driven な unit test を追加する。

## 背景
従来のフィルタは `url.Parse` 後に `Host` が non-empty かどうかしか確認していなかった。古典的な open-redirect ベクタが 2 種類通過していた:
- `javascript:alert(1)` — `url.Parse` は Host を空にして `Opaque` に格納するため、フィルタを通過していた。
- `/\evil.com/path` — 一部のブラウザは backslash を `/` に正規化し、protocol-relative URL として解釈して `evil.com` にリダイレクトする。`url.Parse` の挙動とは一致しない。

いずれもログイン成功後に `/login?return_url=...` を経由してユーザーを攻撃者の origin に飛ばす経路として悪用できる状態だった。

## 確認項目
- [ ] CI green (新規 `TestSanitizeReturnURL` を含む)。
- [ ] Manual: `curl -i "localhost:8080/login?return_url=javascript:alert(1)"` → form action / hidden field の値が `/` になり、payload が出力されないこと。