### PR TITLE
feat(auth): POST /login に IP per レートリミット (burst 10, sustained 0.2/s)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	_ "github.com/jackc/pgx/v5/stdlib"
 	"github.com/labstack/echo/v5"
@@ -83,13 +84,27 @@ func newServer(cfg Config) (http.Handler, error) {
 	}))
 	gen.RegisterHandlers(e, handler)
 	e.GET("/login", handler.GetLogin)
-	e.POST("/login", handler.PostLogin)
+	e.POST("/login", handler.PostLogin, loginRateLimiter())
 	e.GET("/logout", handler.Logout)
 	e.GET("/health", func(c *echo.Context) error {
 		return c.JSON(http.StatusOK, map[string]string{"status": "ok"})
 	})
 
 	return e, nil
+}
+
+func loginRateLimiter() echo.MiddlewareFunc {
+	store := middleware.NewRateLimiterMemoryStoreWithConfig(middleware.RateLimiterMemoryStoreConfig{
+		Rate:      0.2,
+		Burst:     10,
+		ExpiresIn: 10 * time.Minute,
+	})
+	return middleware.RateLimiterWithConfig(middleware.RateLimiterConfig{
+		Store: store,
+		IdentifierExtractor: func(c *echo.Context) (string, error) {
+			return c.RealIP(), nil
+		},
+	})
 }
 
 func postgresDSN(cfg DatabaseConfig) string {


### PR DESCRIPTION
## 概要
Echo の in-memory rate limiter を `POST /login` のみに適用する:
- `Rate`: 0.2 req/s (≈ 12/min sustained)。
- `Burst`: 10。
- Identifier: `c.RealIP()`。
- Entry idle expiry: 10 分。

## 背景
現状はパスワード送信に何の制限もかかっていない。1 つの IP からフォームに対して 1 分あたり数千通の試行を、本物のパスワードバックエンド (`userUseCase.Authenticate`) に直接送信できる状態。基本的な per-IP 上限を入れるだけでも攻撃コストを大きく引き上げられ、実ユーザーには影響しない (typo によるリトライは burst の範囲に収まる)。

## レビュアー向けメモ
- 制限対象は `POST` のみ。`GET /login` (フォーム描画) には適用しない。429 を受けた実ユーザーが page reload する操作までさらに制限されないようにするため。
- memory store は pod ごとに保持されるため、LB 配下で複数 pod に試行が分散すると、許可される試行回数が pod 数倍になる。upstream / global rate limit との組み合わせは別 PR で検討する。
- `c.RealIP()` は Echo が proxy を信頼するよう設定されているときに `X-Forwarded-For` を参照する。本サービスは標準 ingress を前提としている。

## 確認項目
- [ ] CI green。
- [ ] Manual: `for i in {1..15}; do curl -X POST -d 'username=x&password=y' localhost:8080/login -o /dev/null -s -w '%{http_code}\n'; done` → 最初の 10 回が 401、以降が 429 になること。