### PR TITLE
fix(docker): production image を nonroot 化 + Dockerfile 改善

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,9 @@
 
 # Build artifacts
 tmp/
+bin/
+out/
+/portal-oidc
 *.exe
 *.exe~
 *.dll
@@ -17,6 +20,15 @@ tmp/
 *.dylib
 *.test
 *.out
+
+# Local runtime state — must never enter the image
+data/
+*.pem
+*.key
+
+# Logs
+*.log
+logs/
 
 # Documentation
 *.md

--- a/.github/renovate/docker.json5
+++ b/.github/renovate/docker.json5
@@ -1,11 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "docker": {
+    "pinDigests": true
+  },
   "packageRules": [
     {
       "description": "Docker images (non-major)",
       "matchDatasources": ["docker"],
       "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"]
+      "matchUpdateTypes": ["minor", "patch", "digest"]
     },
     {
       "description": "Docker images (major)",

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,16 +59,20 @@ jobs:
       - name: Setup Go
         uses: jdx/mise-action@v4
 
-      - name: Build binary
+      - name: Build binaries
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           COMMIT=$(git rev-parse --short HEAD)
           BUILD_DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-            -trimpath \
-            -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \
-            -o portal-oidc-linux-amd64 \
-            ./cmd
+          LDFLAGS="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}"
+          for arch in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH=${arch} go build \
+              -trimpath \
+              -buildvcs=false \
+              -ldflags="${LDFLAGS}" \
+              -o portal-oidc-linux-${arch} \
+              ./cmd
+          done
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -76,6 +80,7 @@ jobs:
           generate_release_notes: true
           files: |
             portal-oidc-linux-amd64
+            portal-oidc-linux-arm64
 
       - name: Log in to Container Registry
         uses: docker/login-action@v4
@@ -95,6 +100,9 @@ jobs:
             type=semver,pattern={{major}}
             type=sha
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -103,6 +111,7 @@ jobs:
         with:
           context: .
           target: production
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Base stage: Common setup for all stages
 # ============================================================================
-FROM golang:1.26-alpine AS base
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS base
 
 WORKDIR /app
 
@@ -12,14 +12,13 @@ WORKDIR /app
 # ============================================================================
 FROM base AS development
 
-# Install development tools
-RUN go install github.com/air-verse/air@latest
+# renovate: datasource=github-releases depName=air-verse/air
+ARG AIR_VERSION=v1.63.0
+RUN go install github.com/air-verse/air@${AIR_VERSION}
 
-# Copy dependency files first for better layer caching
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
-# Copy source code (will be overwritten by volume mount in compose)
 COPY . .
 
 EXPOSE 8080
@@ -31,31 +30,34 @@ CMD ["air", "-c", ".air.toml"]
 # ============================================================================
 FROM base AS builder
 
-# Build arguments for versioning
 ARG VERSION=dev
 ARG COMMIT=unknown
 ARG BUILD_DATE=unknown
+ARG TARGETOS
+ARG TARGETARCH
 
-# Copy dependency files first for better layer caching
 COPY go.mod go.sum ./
 RUN go mod download && go mod verify
 
-# Copy source code
 COPY . .
 
-# Build static binary with optimizations
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
     -trimpath \
     -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \
-    -o /app/portal-oidc \
+    -o /out/portal-oidc \
     ./cmd
+
+# ============================================================================
+# Data stage: scaffold /app/data writable by the nonroot runtime user
+# ============================================================================
+FROM alpine:3.21 AS data
+RUN mkdir -p /out/data && chown -R 65532:65532 /out/data && chmod 700 /out/data
 
 # ============================================================================
 # Production stage: Distroless runtime image
 # ============================================================================
 FROM gcr.io/distroless/static-debian12:nonroot AS production
 
-# OCI labels
 LABEL org.opencontainers.image.title="portal-oidc" \
       org.opencontainers.image.description="traP Portal OIDC Provider" \
       org.opencontainers.image.source="https://github.com/traPtitech/portal-oidc" \
@@ -64,8 +66,10 @@ LABEL org.opencontainers.image.title="portal-oidc" \
 
 WORKDIR /app
 
-# Copy the binary
-COPY --from=builder /app/portal-oidc /app/portal-oidc
+COPY --from=builder --chown=65532:65532 /out/portal-oidc /app/portal-oidc
+COPY --from=data    --chown=65532:65532 /out/data        /app/data
+
+USER 65532:65532
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Base stage
 # ============================================================================
-FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:f85330846cde1e57ca9ec309382da3b8e6ae3ab943d2739500e08c86393a21b1 AS base
 
 WORKDIR /app
 ENV CGO_ENABLED=0 \
@@ -63,7 +63,7 @@ RUN mkdir -p /out/data && chown 65532:65532 /out/data && chmod 700 /out/data
 # ============================================================================
 # Production stage: distroless runtime image
 # ============================================================================
-FROM gcr.io/distroless/static-debian12:nonroot AS production
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1 AS production
 
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,8 +80,8 @@ LABEL org.opencontainers.image.title="portal-oidc" \
 
 WORKDIR /app
 
-COPY --from=builder --chown=65532:65532 /out/portal-oidc /app/portal-oidc
-COPY --from=builder --chown=65532:65532 /out/data        /app/data
+COPY --from=builder --link --chown=65532:65532 /out/portal-oidc /app/portal-oidc
+COPY --from=builder --link --chown=65532:65532 /out/data        /app/data
 
 USER 65532:65532
 STOPSIGNAL SIGTERM

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,29 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 
 # ============================================================================
-# Base stage: Common setup for all stages
+# Base stage
 # ============================================================================
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS base
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine AS base
 
 WORKDIR /app
+ENV CGO_ENABLED=0 \
+    GOTOOLCHAIN=local \
+    GOFLAGS=-mod=readonly
 
 # ============================================================================
-# Development stage: Hot-reload with Air
+# Development stage: hot-reload with Air
 # ============================================================================
 FROM base AS development
 
 # renovate: datasource=github-releases depName=air-verse/air
 ARG AIR_VERSION=v1.63.0
-RUN go install github.com/air-verse/air@${AIR_VERSION}
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    GOFLAGS= go install github.com/air-verse/air@${AIR_VERSION}
 
 COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download && go mod verify
 
 COPY . .
 
@@ -26,7 +32,7 @@ EXPOSE 8080
 CMD ["air", "-c", ".air.toml"]
 
 # ============================================================================
-# Builder stage: Compile the application
+# Builder stage: compile the application
 # ============================================================================
 FROM base AS builder
 
@@ -36,40 +42,49 @@ ARG BUILD_DATE=unknown
 ARG TARGETOS
 ARG TARGETARCH
 
-COPY go.mod go.sum ./
-RUN go mod download && go mod verify
+RUN --mount=type=bind,source=go.mod,target=go.mod \
+    --mount=type=bind,source=go.sum,target=go.sum \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download && go mod verify
 
-COPY . .
+RUN --mount=type=bind,target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build,id=gobuild-${TARGETOS}-${TARGETARCH} \
+    GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} \
+    go build \
+      -trimpath \
+      -buildvcs=false \
+      -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \
+      -o /out/portal-oidc \
+      ./cmd
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH:-amd64} go build \
-    -trimpath \
-    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.buildDate=${BUILD_DATE}" \
-    -o /out/portal-oidc \
-    ./cmd
+RUN mkdir -p /out/data && chown 65532:65532 /out/data && chmod 700 /out/data
 
 # ============================================================================
-# Data stage: scaffold /app/data writable by the nonroot runtime user
-# ============================================================================
-FROM alpine:3.21 AS data
-RUN mkdir -p /out/data && chown -R 65532:65532 /out/data && chmod 700 /out/data
-
-# ============================================================================
-# Production stage: Distroless runtime image
+# Production stage: distroless runtime image
 # ============================================================================
 FROM gcr.io/distroless/static-debian12:nonroot AS production
+
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG BUILD_DATE=unknown
 
 LABEL org.opencontainers.image.title="portal-oidc" \
       org.opencontainers.image.description="traP Portal OIDC Provider" \
       org.opencontainers.image.source="https://github.com/traPtitech/portal-oidc" \
       org.opencontainers.image.vendor="traP" \
-      org.opencontainers.image.licenses="MIT"
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.version="${VERSION}" \
+      org.opencontainers.image.revision="${COMMIT}" \
+      org.opencontainers.image.created="${BUILD_DATE}"
 
 WORKDIR /app
 
 COPY --from=builder --chown=65532:65532 /out/portal-oidc /app/portal-oidc
-COPY --from=data    --chown=65532:65532 /out/data        /app/data
+COPY --from=builder --chown=65532:65532 /out/data        /app/data
 
 USER 65532:65532
+STOPSIGNAL SIGTERM
 
 EXPOSE 8080
 


### PR DESCRIPTION
## 概要
1 commit で開いた後に何度か追加のコミットを重ねたので、まとめて記載する。

### Production hardening
- `USER 65532:65532` を明示する。`:nonroot` tag のデフォルトに依存せず、Dockerfile 側で固定する。
- `COPY --chown=65532:65532` でバイナリと `/app/data` を nonroot 所有にする。
- builder 内で `/out/data` を 700 で事前作成し、それを COPY する。これまで初回起動時の `rsa.GenerateKey` → `data/private.pem` への書き込みが nonroot で失敗するため、外部 volume mount が前提になっていた。
- `STOPSIGNAL SIGTERM` を設定する (#146 の graceful shutdown と整合)。

### 再現性
- base image を sha256 digest で pin する (`golang:1.26.2-alpine@sha256:...`、`distroless/static-debian12:nonroot@sha256:...`)。renovate の `docker.json5` でも `pinDigests: true` を有効化し、`digest` update を auto-merge 対象に加える。
- Go バージョンを mise.toml に揃えて `1.26.2` に固定する。
- `-buildvcs=false`、`GOTOOLCHAIN=local` を設定する。

### ビルド速度
- `# syntax=docker/dockerfile:1.7` を指定する。
- `--mount=type=cache` で `/go/pkg/mod` と `/root/.cache/go-build` を全 RUN にかける。後者は `id=gobuild-${TARGETOS}-${TARGETARCH}` で arch ごとに分離する。
- builder で `COPY . .` をやめ、`--mount=type=bind,target=.` に置き換える。
- `COPY --link` で final stage の COPY 2 行を独立 layer に分離する。
- 別 stage だった alpine `data` stage を builder に統合する (同じ alpine なので 1 layer 削減できる)。

### Multi-arch
- builder を `--platform=$BUILDPLATFORM` に固定し、`TARGETOS` / `TARGETARCH` で cross-compile する。
- release workflow に `docker/setup-qemu-action` を追加し、`platforms: linux/amd64,linux/arm64` を指定する。
- release artifact にも arm64 バイナリを追加する。

### Secret 漏れ対策
- `.dockerignore` を強化する:
  - `data/`、`*.pem`、`*.key` を除外する (`data/private.pem` が dev image の layer に焼き込まれていた)。
  - `/portal-oidc` を除外する (リポジトリ root に残る古いローカルバイナリ、29 MB)。
  - `bin/`、`out/`、`*.log`、`logs/` も追加する。

### その他
- air を `@latest` から `v1.63.0` に pin し、renovate marker を付ける。
- OCI label に `image.version` / `image.revision` / `image.created` を追加する。

## 動作確認
```
$ docker build --target production -t portal-oidc:final .
$ docker inspect portal-oidc:final --format '{{.Config.User}} {{.Config.StopSignal}} {{.Config.WorkingDir}}'
65532:65532 SIGTERM /app
$ docker images portal-oidc:final --format '{{.Size}}'
25.8MB
$ time docker build --target production .   # warm cache rebuild
~1.3s
```

## レビュアー向けメモ
- 開発 stage は引き続き root のままにしている。compose の `/root/.cache/go-build` mount と一緒に修正する必要があるため、別 PR に切り出す予定。
- distroless static には tzdata が含まれない。OAuth/OIDC で扱うタイムスタンプは元々 UTC なので影響はない。
- `/app/data` を 700 で焼き込んでいるため、K8s で PV を mount する場合は `securityContext.fsGroup: 65532` が必要になる。

## 確認項目
- [ ] CI green。Build job が production target を build するため、失敗すれば検知できる。
- [ ] Manual: `docker run --rm <image>` で nonroot 起動・key 生成・bind 起動まで通ること。
- [ ] Multi-arch: `docker buildx build --platform linux/arm64 --target production .` が通ること。