### PR TITLE
fix: dev environment build and DB connection errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Base stage: Common setup for all stages
 # ============================================================================
-FROM golang:1.26.2-alpine AS base
+FROM golang:1.26.3-alpine AS base
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Base stage: Common setup for all stages
 # ============================================================================
-FROM golang:1.26-alpine AS base
+FROM golang:1.26.2-alpine AS base
 
 WORKDIR /app
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
       - CONFIG_FILE=/app/config.yaml
       - TZ=Asia/Tokyo
       - OIDC_DATABASE__HOST=oidc
-      - OIDC_DATABASE__PORT=5433
+      - OIDC_DATABASE__PORT=5432
       - OIDC_PORTAL__DATABASE__HOST=portal
       - OIDC_PORTAL__DATABASE__PORT=5432
     depends_on:
@@ -35,7 +35,7 @@ services:
       TZ: Asia/Tokyo
     volumes:
       - ./db/portal-schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
-      - portal-pg-data:/var/lib/postgresql/data
+      - portal-pg-data:/var/lib/postgresql
     ports:
       - "5432:5432"
     healthcheck:
@@ -55,7 +55,7 @@ services:
       TZ: Asia/Tokyo
     volumes:
       - ./db/schema.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro
-      - oidc-pg-data:/var/lib/postgresql/data
+      - oidc-pg-data:/var/lib/postgresql
     ports:
       - "5433:5432"
     healthcheck:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traPtitech/portal-oidc
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/alecthomas/kong v1.15.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.2"
+go = "1.26.3"
 golangci-lint = "2.12.1"
 atlas = "1.2.0"
 tbls = "1.94.5"

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 go = "1.26.3"
-golangci-lint = "2.12.1"
+golangci-lint = "2.12.2"
 atlas = "1.2.0"
 tbls = "1.94.5"
 pre-commit = "4.6.0"


### PR DESCRIPTION
## Summary

Docker Compose 開発環境で `air` 起動時に出ていたエラー群を修正し、合わせて `net` パッケージの脆弱性 (GO-2026-4971) のため Go を 1.26.3 にバンプ、ついでに golangci-lint も最新パッチ 2.12.2 に揃えます。

- **Go バージョン / GO-2026-4971**: Dockerfile が `golang:1.26-alpine` (実体は 1.26.1) を参照していて `go.mod`/`mise.toml` の要求を満たさず `GOTOOLCHAIN=local` 下でビルド失敗していた。さらに `net@go1.26.2` には `Panic in Dial and LookupPort when handling NUL byte on Windows` の脆弱性あり → `Dockerfile`/`mise.toml`/`go.mod` をすべて `1.26.3` にピン留め
- **OIDC DB 接続失敗**: app コンテナから `oidc:5433` に接続しようとして refused。`5433` はホスト公開ポートで、コンテナ内 PostgreSQL は `5432` listen のため Docker network 内通信ではコンテナ内ポートを使う必要がある → `OIDC_DATABASE__PORT=5432` に修正
- **postgres:18 volume パス**: postgres 18 の data ディレクトリ仕様に合わせて `/var/lib/postgresql/data` → `/var/lib/postgresql` に変更
- **golangci-lint**: `2.12.1` → `2.12.2` (パッチアップデート)

## Test plan

- [x] `docker compose build --pull app` がエラーなく完了する
- [x] `docker compose up -d` 後、`portal` / `oidc` コンテナが healthy
- [x] app コンテナが起動し air が `Starting server on :8080` を出力する (DB ping 成功)
- [x] `mise run dev` 経由でも `built with Go go1.26.3` でビルド・起動成功
- [x] `curl http://localhost:8080/` が応答を返す (HTTP 404 だが server 起動を確認)
- [x] `mise install golangci-lint@2.12.2` が成功 (GitHub attestations 検証パス)

🤖 Generated with [Claude Code](https://claude.com/claude-code)