### PR TITLE
security: サプライチェーンハードニング対応（提案・自動生成）

### DIFF
--- a/.github/conformance/docker-compose.yml
+++ b/.github/conformance/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   mongodb:
-    image: mongo:8.3.2
+    image: mongo:8.3.2@sha256:8dbb3db48a72084457272d33d398ae0ef7db8e7c9e12815a295c3417c8df6d38
   httpd:
     image: ${CONFORMANCE_HTTPD_IMAGE}
     ports:

--- a/.github/workflows/build-conformance-suite.yaml
+++ b/.github/workflows/build-conformance-suite.yaml
@@ -35,7 +35,7 @@ jobs:
           docker compose -f builder-compose.yml run --rm builder
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,11 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
         with:
           install-mode: none
           args: --config=.golangci.yml
@@ -36,9 +36,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Build
         run: go build -v ./...
@@ -80,9 +80,9 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run tests
         run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
@@ -91,7 +91,7 @@ jobs:
           POSTGRES_PORT: "5433"
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         continue-on-error: true
         with:
           files: coverage.out
@@ -103,9 +103,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run govulncheck
         run: |
@@ -119,15 +119,15 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run Gosec Security Scanner
         run: gosec -exclude-generated -fmt sarif -out gosec.sarif ./...
 
       - name: Upload Gosec SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         if: always() && hashFiles('gosec.sarif') != ''
         with:
           sarif_file: gosec.sarif

--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -41,13 +41,13 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: ${{ env.GO_VERSION_FILE }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.14"
 
@@ -94,7 +94,7 @@ jobs:
           exit 1
 
       - name: Login to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -130,7 +130,7 @@ jobs:
           DISCOVERY_URL: http://host.docker.internal:8080/.well-known/openid-configuration
 
       - name: Upload test results
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: conformance-results

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,9 @@ jobs:
           --health-timeout=5s
           --health-retries=5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - uses: jdx/mise-action@v4
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Run tests
         run: go test -race ./...
@@ -52,12 +52,12 @@ jobs:
     outputs:
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
 
       - name: Build binary
         run: |
@@ -71,14 +71,14 @@ jobs:
             ./cmd
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           generate_release_notes: true
           files: |
             portal-oidc-linux-amd64
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -86,7 +86,7 @@ jobs:
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -96,10 +96,10 @@ jobs:
             type=sha
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           target: production

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -42,11 +42,11 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RENOVATE_APP_ID }}
           private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Override default config from dispatch variables
         shell: bash
         env:
@@ -56,7 +56,7 @@ jobs:
           echo "RENOVATE_DRY_RUN=${INPUT_DRY_RUN:-$RENOVATE_DRY_RUN}" >> "${GITHUB_ENV}"
           echo "LOG_LEVEL=${INPUT_LOG_LEVEL:-$LOG_LEVEL}" >> "${GITHUB_ENV}"
       - name: Renovate
-        uses: renovatebot/github-action@v46.1.14
+        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           renovate-image: "ghcr.io/renovatebot/renovate"
           renovate-version: "latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================================================
 # Base stage: Common setup for all stages
 # ============================================================================
-FROM golang:1.26.3-alpine AS base
+FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS base
 
 WORKDIR /app
 
@@ -53,7 +53,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
 # ============================================================================
 # Production stage: Distroless runtime image
 # ============================================================================
-FROM gcr.io/distroless/static-debian12:nonroot AS production
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:d093aa3e30dbadd3efe1310db061a14da60299baff8450a17fe0ccc514a16639 AS production
 
 # OCI labels
 LABEL org.opencontainers.image.title="portal-oidc" \

--- a/compose.yaml
+++ b/compose.yaml
@@ -27,7 +27,7 @@ services:
     stdin_open: true
 
   portal:
-    image: postgres:18
+    image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: portal
@@ -47,7 +47,7 @@ services:
     restart: unless-stopped
 
   oidc:
-    image: postgres:18
+    image: postgres:18@sha256:8ff36f3c66371cba71d20ceedccfc3de9669a68737607888c4ef0af93abe8e39
     environment:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: oidc
@@ -67,7 +67,7 @@ services:
     restart: unless-stopped
 
   adminer:
-    image: adminer:5.4.2-standalone
+    image: adminer:5.4.2-standalone@sha256:cc64d253db4f016cbcff2ff2f01e60ed07e74f38b4398f84d3c4fae4b5ce0e07
     environment:
       ADMINER_DEFAULT_SERVER: portal
       ADMINER_DESIGN: pepa-linha


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> CI／サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・CI が通るかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。不要なものは部分的に revert／close いただいて構いません。

traPtitech org 全体のセキュリティ監査に基づく提案です。

## 適用した変更

### ✅ GitHub Actions を commit SHA で固定（31 箇所）
タグ／ブランチ参照は可変で付け替えられ得るため、不変な commit SHA に固定しました（[pinact](https://github.com/suzuki-shunsuke/pinact) を使用）。`# vX` コメントを残しているので **Dependabot / Renovate は引き続き自動更新できます**。

### ✅ Docker ベースイメージを digest 固定（6 箇所）
信頼できる発行元（Docker 公式 / distroless / ghcr.io/traPtitech 等）の可変タグに `@sha256:...` を付与しました。
- `mongo:8.3.2`（`.github/conformance/docker-compose.yml`）
- `golang:1.26.3-alpine`（`Dockerfile`）
- `gcr.io/distroless/static-debian12:nonroot`（`Dockerfile`）
- `postgres:18`（`compose.yaml`）
- `postgres:18`（`compose.yaml`）
- `adminer:5.4.2-standalone`（`compose.yaml`）

## 確認のお願い
- [ ] CI が通ることを確認した

## 参考
- SHA pinning: [pinact](https://github.com/suzuki-shunsuke/pinact) ／ Dependabot（`github-actions`）・Renovate（`helpers:pinGitHubActionDigests`）でも自動更新できます
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。