### PR TITLE
fix(conformance): CI の Mongo featureCompatibilityVersion を mongo 8.3 に追従

### DIFF
--- a/.github/conformance/docker-compose.yml
+++ b/.github/conformance/docker-compose.yml
@@ -10,7 +10,7 @@ services:
   server:
     image: ${CONFORMANCE_SERVER_IMAGE}
     environment:
-      - openid.mongodb.targetFeatureCompatibilityVersion=8.2
+      - openid.mongodb.targetFeatureCompatibilityVersion=8.3
     command: >
       java
       -Djdk.tls.maxHandshakeMessageSize=65536


### PR DESCRIPTION
## 概要

#156 (da415e1) で CI の MongoDB イメージが `mongo:8.2.7 → 8.3.2` にバンプされて以降、main の **OIDC Conformance Suite ワークフローが起動待ちタイムアウトで失敗し続けている**（[失敗 run](https://github.com/traPtitech/portal-oidc/actions/runs/26696242453)。#156 マージ直後から）。compose が conformance-server に渡す FCV target を `8.2 → 8.3` に追従させて修正する。

## 原因

1. `.github/conformance/docker-compose.yml` は conformance-server に `openid.mongodb.targetFeatureCompatibilityVersion=8.2` を渡している
2. conformance-suite は起動時に「現在の FCV ≠ target なら `setFeatureCompatibilityVersion` を実行」する（`Application.java`）
3. フレッシュな mongo 8.3.2 コンテナは FCV=8.3 で初期化されるため、**8.3 → 8.2 のダウングレード**を要求する形になる
4. MongoDB は FCV ダウングレードに `confirm: true` を要求し、コマンドを拒否（code 7369100）:

   ```
   mongodb server version is '8.3.2', featureCompatibilityVersion is currently '8.3'
    and openid.mongodb.targetFeatureCompatibilityVersion is '8.2'
   ERROR ... Application run failed
   MongoCommandException: ... re-run this command with 'confirm: true' ...
   ```

5. conformance-server が起動時クラッシュ → httpd が 503 → 「Wait for conformance suite」が 300 秒でタイムアウト

## 修正

target を 8.3 に揃える（1行）。CI の mongo volume は毎回フレッシュで FCV は常に 8.3 のため、文字列一致で `setFeatureCompatibilityVersion` 自体が実行されず起動が通る。前回の mongo バンプ時に 392a72d が行ったのと同じ追従。

## 補足

- Renovate が今後 mongo をマイナーバンプした際も、この env var の追従が同時に必要（今回の再発防止は Renovate の `packageRules` でのグルーピング等が考えられるが、本 PR ではスコープ外）
- main が赤のため、オープン中の各 PR（#128 等）の Conformance Suite ジョブも同じ理由で失敗している。本 PR マージ後、各 PR は main を取り込めば解消する

🤖 Generated with [Claude Code](https://claude.com/claude-code)