### PR TITLE
fix(ci): manage govulncheck with mise

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,9 +108,7 @@ jobs:
       - uses: jdx/mise-action@v4
 
       - name: Run govulncheck
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+        run: govulncheck ./...
 
   security:
     name: Security Scan

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ pre-commit = "4.6.0"
 "go:github.com/sqlc-dev/sqlc/cmd/sqlc" = "1.31.1"
 "go:github.com/securego/gosec/v2/cmd/gosec" = "2.28.0"
 "go:github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen" = "2.7.2"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.6.0"
 
 # =============================================================================
 # Development


### PR DESCRIPTION
changes in `jdx/mise-action` caused fails in `Vulnerability Check`, one of the ci jobs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - セキュリティ脆弱性チェックの実行環境を整理し、検査ツールを固定バージョンで管理するよう改善しました。
  - 継続的インテグレーションにおける脆弱性検査の安定性と再現性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->